### PR TITLE
Debug: 1. cache refresh at every init; 2. compute cardinality only once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,4 +140,5 @@ dmypy.json
 
 # Developer's local tests
 *localtest.py
+data-localtest/
 

--- a/causallearn/graph/GraphClass.py
+++ b/causallearn/graph/GraphClass.py
@@ -44,8 +44,6 @@ class CausalGraph:
         self.cardinalities = None # only works when self.data is discrete, i.e. self.test is chisq or gsq
         self.is_discrete = False
         self.citest_cache = dict()
-        self.data_hash_key = None
-        self.ci_test_hash_key = None
 
     def set_ind_test(self, indep_test, mvpc=False):
         """Set the conditional independence test that will be used"""
@@ -53,7 +51,6 @@ class CausalGraph:
         if mvpc:
             self.mvpc = True
         self.test = indep_test
-        self.ci_test_hash_key = hash(indep_test)
 
     def ci_test(self, i, j, S):
         """Define the conditional independence test"""
@@ -62,7 +59,7 @@ class CausalGraph:
             return self.test(self.data, self.nx_skel, self.prt_m, i, j, S, self.data.shape[0])
 
         i, j = (i, j) if (i < j) else (j, i)
-        ijS_key = (i, j, frozenset(S), self.data_hash_key, self.ci_test_hash_key)
+        ijS_key = (i, j, frozenset(S))
         if ijS_key in self.citest_cache:
             return self.citest_cache[ijS_key]
         # if discrete, assert self.test is chisq or gsq, pass into cardinalities

--- a/causallearn/search/ConstraintBased/FCI.py
+++ b/causallearn/search/ConstraintBased/FCI.py
@@ -191,14 +191,8 @@ class SepsetsPossibleDsep():
                 choice = cg.next()
 
                 X, Y = self.graph.node_map[node_1], self.graph.node_map[node_2]
-                X, Y = (X, Y) if (X < Y) else (Y, X)
-                XYS_key = (X, Y, frozenset(condSet))
-                if XYS_key in Fas.citest_cache:
-                    p_value = Fas.citest_cache[XYS_key]
-                else:
-                    p_value = self.independence_test(self.data, X, Y, tuple(condSet), Fas.cardinalities) if Fas.is_discrete \
-                            else self.independence_test(self.data, X, Y, tuple(condSet))
-                    Fas.citest_cache[XYS_key] = p_value
+                p_value = Fas.ci_test(self.independence_test, self.data,
+                                        X, Y, tuple(condSet))
                 independent = p_value > self.alpha
 
                 if independent and noEdgeRequired:
@@ -439,30 +433,18 @@ def doDdpOrientation(node_d, node_a, node_b, node_c, previous, graph, data, inde
     path = getPath(node_d, previous)
 
     X, Y = graph.node_map[node_d], graph.node_map[node_c]
-    X, Y = (X, Y) if (X < Y) else (Y, X)
     condSet = tuple([graph.node_map[nn] for nn in path])
-    XYS_key = (X, Y, frozenset(condSet))
-    if XYS_key in Fas.citest_cache:
-        p_value = Fas.citest_cache[XYS_key]
-    else:
-        p_value = independence_test_method(data, X, Y, condSet, Fas.cardinalities) if Fas.is_discrete \
-                    else independence_test_method(data, X, Y, condSet)
-        Fas.citest_cache[XYS_key] = p_value
+    p_value = Fas.ci_test(independence_test_method, data,
+                      X, Y, tuple(condSet))
     ind = p_value > alpha
 
     path2 = list(path)
     path2.remove(node_b)
 
     X, Y = graph.node_map[node_d], graph.node_map[node_c]
-    X, Y = (X, Y) if (X < Y) else (Y, X)
     condSet = tuple([graph.node_map[nn2] for nn2 in path2])
-    XYS_key = (X, Y, frozenset(condSet))
-    if XYS_key in Fas.citest_cache:
-        p_value2 = Fas.citest_cache[XYS_key]
-    else:
-        p_value2 = independence_test_method(data, X, Y, condSet, Fas.cardinalities) if Fas.is_discrete \
-                    else independence_test_method(data, X, Y, condSet)
-        Fas.citest_cache[XYS_key] = p_value2
+    p_value2 = Fas.ci_test(independence_test_method, data,
+                          X, Y, condSet)
     ind2 = p_value2 > alpha
 
     if not ind and not ind2:

--- a/causallearn/search/ConstraintBased/PC.py
+++ b/causallearn/search/ConstraintBased/PC.py
@@ -4,7 +4,7 @@ from itertools import permutations, combinations
 
 import networkx as nx
 import numpy as np
-
+from causallearn.utils import Fas
 from causallearn.graph.GraphClass import CausalGraph
 from causallearn.utils.PCUtils import SkeletonDiscovery, UCSepset, Meek, Helper
 from causallearn.utils.PCUtils.BackgroundKnowledgeOrientUtils import orient_by_background_knowledge
@@ -71,6 +71,7 @@ def pc_alg(data, alpha, indep_test, stable, uc_rule, uc_priority, background_kno
     cg_1 = SkeletonDiscovery.skeleton_discovery_using_fas(data, alpha, indep_test, stable,
                                                 background_knowledge=background_knowledge, verbose=verbose,
                                                 show_progress=show_progress)
+    cg_1.citest_cache = Fas.citest_cache # for citests in further UCSepset.uc_sepset
 
     if background_knowledge is not None:
         orient_by_background_knowledge(cg_1, background_knowledge)

--- a/causallearn/utils/cit.py
+++ b/causallearn/utils/cit.py
@@ -176,15 +176,13 @@ def fisherz(data, X, Y, condition_set, correlation_matrix=None):
     return p
 
 
-def chisq(data, X, Y, conditioning_set, cardinalities=None):
+def chisq(data, X, Y, conditioning_set, cardinalities):
     # though cardinalities can be computed from data, here we pass it as argument,
     # to prevent from repeated computation on each variable's vardinality
-    if cardinalities is None: cardinalities = np.max(data, axis=0) + 1
     indexs = list(conditioning_set) + [X, Y]
     return chisq_or_gsq_test(data[:, indexs].T, cardinalities[indexs])
 
-def gsq(data, X, Y, conditioning_set, cardinalities=None):
-    if cardinalities is None: cardinalities = np.max(data, axis=0) + 1
+def gsq(data, X, Y, conditioning_set, cardinalities):
     indexs = list(conditioning_set) + [X, Y]
     return chisq_or_gsq_test(data[:, indexs].T, cardinalities[indexs], G_sq=True)
 


### PR DESCRIPTION
### Bugs solved:
1. About cache refresh:
 + Manually refresh cache at every init. Added one refresh line at `SkeletonDiscovery.py:L145` (for PC) and `FCI.py:L615` (for FCI).
 + Deprecate `hash(data.tobytes())` - it's slow. @chenweiDelight also mentions a faster `hash(str(data))` - but let's just init refresh and use no hash.

2. About passing cardinality chisq or gsq:
 + Added `cardinalities` and `is_discrete` at `Fas.py:L10`, and calculate cardinalities only once at `SkeletonDiscovery.py:L165` (for PC) and `FCI.py:L625` (for FCI). No need to `np.max()` every time.

### TODO: still debugging:
Now PC results with/without fas (change `PC.py:L71`) respectively:

| data (#nodes/#edges)<br>time (sec) | without fas time | with fas time | SHD(without fas, with fas) |
|:----------------------------------:|:----------------:|:-------------:|:--------------------------:|
|             cancer 5/4             |       0.009      |     0.009     |              0             |
|           earthquake 5/4           |       0.012      |      0.01     |              0             |
|             survey 6/6             |       0.014      |     0.015     |              0             |
|              asia 8/8              |       0.024      |     0.025     |              0             |
|             sachs 11/17            |       0.142      |     0.148     |              0             |
|             child 20/25            |       0.618      |     0.699     |              4             |
|           insurance 27/52          |       1.45       |     1.823     |              3             |
|             water 32/66            |       0.321      |     0.365     |              0             |
|             alarm 37/46            |       0.873      |     1.015     |              1             |
|            barley 48/84            |       3.466      |      4.95     |              0             |
|          hailfinder 56/66          |       0.938      |     1.588     |              0             |
|            hepar2 70/123           |       9.482      |     11.949    |              3             |
|           win95pts 76/112          |       3.381      |     4.504     |              0             |
|            andes 223/338           |      26.741      |     45.722    |              0             |

So two problems:
1. Still small SHD difference at datasets e.g. `child`.
2. Still time difference, e.g. `andes` 26s vs 45s - though before solving cardinalities issue, it's ~300s.
3. See profiling stat: callings count on chisq is different on with/without fas.