### PR TITLE
add the background_knowledge when call mvpc_alg() in pc()

### DIFF
--- a/causallearn/search/ConstraintBased/PC.py
+++ b/causallearn/search/ConstraintBased/PC.py
@@ -22,7 +22,8 @@ def pc(data, alpha=0.05, indep_test=fisherz, stable=True, uc_rule=0, uc_priority
         if indep_test == fisherz:
             indep_test = mv_fisherz
         return mvpc_alg(data=data, alpha=alpha, indep_test=indep_test, correction_name=correction_name, stable=stable,
-                        uc_rule=uc_rule, uc_priority=uc_priority, verbose=verbose, show_progress=show_progress)
+                        uc_rule=uc_rule, uc_priority=uc_priority, background_knowledge=background_knowledge, verbose=verbose, 
+                        show_progress=show_progress)
     else:
         return pc_alg(data=data, alpha=alpha, indep_test=indep_test, stable=stable, uc_rule=uc_rule,
                       uc_priority=uc_priority, background_knowledge=background_knowledge, verbose=verbose,


### PR DESCRIPTION
As for the current version, mvpc_alg() has a parameter background_knowledge, but pc() didn't assign the input background_knowledge to it. Now the value is assigned.