### PR TITLE
The initial modification and the test file for test-wise deletion PC

### DIFF
--- a/causallearn/utils/cit.py
+++ b/causallearn/utils/cit.py
@@ -88,7 +88,7 @@ def mv_fisherz(mvdata, X, Y, condition_set, sample_size=None):
     r = -inv[0, 1] / sqrt(inv[0, 0] * inv[1, 1])
     Z = 0.5 * log((1 + r) / (1 - r))
     X = sqrt(sample_size - len(condition_set) - 3) * abs(Z)
-    p = 1 - norm.cdf(abs(X))
+    p = 2*(1 - norm.cdf(abs(X)))
     return p
 
 
@@ -413,6 +413,7 @@ def get_index_mv_rows(mvdata):
 
 def get_sub_correlation_matrix(mvdata):
     indxRows = get_index_mv_rows(mvdata)
+    assert len(indxRows) != 0, "A test-wise deletion fisher-z test appears no overlapping data of involved variables. Please check the input data."
     submatrix = np.corrcoef(mvdata[indxRows, :], rowvar=False)
     sample_size = len(indxRows)
     return submatrix, sample_size

--- a/tests/TestMVPC_mv_fisherz.py
+++ b/tests/TestMVPC_mv_fisherz.py
@@ -1,0 +1,109 @@
+import os
+import sys
+import timeit
+# get current directory
+path = os.getcwd()
+# get parent directory
+path=os.path.abspath(os.path.join(path, os.pardir))
+sys.path.append(path)
+
+import unittest
+import numpy as np
+from causallearn.utils.cit import fisherz, mv_fisherz
+from causallearn.search.ConstraintBased.PC import (get_adjacancy_matrix,pc)
+
+def causal_graph_diff(cg1, cg2):
+    ''' Compare the differences between the causal graphs'''
+    adj1 = get_adjacancy_matrix(cg1)
+    adj2 = get_adjacancy_matrix(cg2)
+    count = 0
+    diff_ls = []
+    for i in range(len(adj1[:, ])):
+        for j in range(len(adj2[:, ])):
+            if adj1[i, j] != adj2[i, j]:
+                diff_ls.append((i, j))
+                count += 1
+    return count
+
+#####################
+
+class Test_test_wise_deletion_PC(unittest.TestCase):
+
+    # example1
+    def test_pc_with_mv_fisherz_full_data(self):
+        data_path = "data_linear_10.txt"
+        data = np.loadtxt(data_path, skiprows=1)  # Import the file at data_path as data
+
+        print('Running PC')
+        start = timeit.default_timer()
+        cg_pc = pc(data, 0.05, fisherz, True, 0,-1)  # Run PC and obtain the estimated graph (CausalGraph object)
+        stop = timeit.default_timer()
+        t_pc = stop - start
+
+        print('Running test-wise deletion PC')
+        start = timeit.default_timer()
+        cg_test_wise_pc = pc(data, 0.05, mv_fisherz, True, 0,-1)  # Run PC and obtain the estimated graph (CausalGraph object)
+        stop = timeit.default_timer()
+        t_test_wise_pc = stop - start
+
+        print(f'Time comparison:\n pc: {t_pc}s, test-wise pc: {t_test_wise_pc}')
+        print(f'Result differences (0 means no difference between the results of different methods):\n pc and test-wise pc:{causal_graph_diff(cg_pc, cg_test_wise_pc)}')
+
+    def test_pc_with_mv_fisherz_MCAR_data(self):
+        data_path = "data_linear_10.txt"
+        data = np.loadtxt(data_path, skiprows=1)  # Import the file at data_path as data
+        
+        #**************** baseline methods: PC on full data ****************#
+        print('Running PC')
+        start = timeit.default_timer()
+        cg_pc = pc(data, 0.05, fisherz, True, 0,-1)  # Run PC and obtain the estimated graph (CausalGraph object)
+        stop = timeit.default_timer()
+        t_pc = stop - start
+
+        #**************** Test-wise deletion PC on MCAR data (Missing less than a half) ****************#
+        nrow,ncol = data.shape        
+        random_mask = np.random.rand(nrow,ncol) > 1
+        mdata = data
+        mdata[random_mask] = None
+        
+        print('Running test-wise deletion PC')
+        start = timeit.default_timer()
+        cg_test_wise_pc = pc(mdata, 0.05, mv_fisherz, True, 0,-1)  # Run PC and obtain the estimated graph (CausalGraph object)
+        stop = timeit.default_timer()
+        t_test_wise_pc = stop - start
+
+        print(f'Time comparison:\n pc: {t_pc}s, test-wise pc: {t_test_wise_pc}')
+        print(f'Result differences (0 means no difference between the results of different methods):\n pc and test-wise pc:{causal_graph_diff(cg_pc, cg_test_wise_pc)}')
+
+        
+    
+    def test_pc_with_mv_fisherz_MCAR_data_assertion(self):
+        data_path = "data_linear_10.txt"
+        data = np.loadtxt(data_path, skiprows=1)  # Import the file at data_path as data
+
+        #**************** Test-wise deletion PC on MCAR data (About a half of the data is missing) ****************#
+        print('Running test-wise deletion PC: Expect an assertion due to too many missing data ')
+        nrow,ncol = data.shape        
+        random_mask = np.random.rand(nrow,ncol) > 0
+        mdata = data
+        mdata[random_mask] = None
+
+        start = timeit.default_timer()
+        cg_test_wise_pc = pc(mdata, 0.05, mv_fisherz, True, 0,-1)  # Run PC and obtain the estimated graph (CausalGraph object)
+        stop = timeit.default_timer()
+        t_test_wise_pc = stop - start
+
+################################################################
+
+if __name__ == '__main__':
+    test = Test_test_wise_deletion_PC()
+    print('------------------------------')
+    print('Test test-wise deletion PC on full datatsets.')
+    test.test_pc_with_mv_fisherz_full_data()
+    print('------------------------------')
+    print('Test test-wise deletion PC on MCAR datatsets.')
+    test.test_pc_with_mv_fisherz_MCAR_data()
+    print('------------------------------')
+    print('Test test-wise deletion PC on MCAR datatsets where most values are missing.')
+    test.test_pc_with_mv_fisherz_MCAR_data_assertion()
+    


### PR DESCRIPTION
1. Make the mv_fisherz() test consistent with the fisherz() test; 
2. Add the test file for test-wise deletion PC. 

The testing logic is that 
* When applying PC and test-wise deletion PC to the data without missing values, their results should be the same.
* When applying PC and test-wise deletion PC to the data with MCAR missing values, their results should be the same.
* When most of the data with MCAR missing values, especially if there are no overlapping data of involved variables, the algorithm should show a warning/error with assertion.
![Screenshot 2022-06-21 at 15 59 14](https://user-images.githubusercontent.com/22346392/174817982-543e9fba-7889-430c-8915-ecbf7dbd56ee.png)
![Screenshot 2022-06-21 at 15 59 32](https://user-images.githubusercontent.com/22346392/174818059-f7d6033f-3106-4189-bf38-4058fa02c548.png)

