### PR TITLE
MVPC: Update mv_fisherz()

### DIFF
--- a/causallearn/graph/GraphClass.py
+++ b/causallearn/graph/GraphClass.py
@@ -60,7 +60,7 @@ class CausalGraph:
         """Define the conditional independence test"""
         # assert i != j and not i in S and not j in S
         if self.mvpc:
-            return self.test(self.data, self.nx_skel, self.prt_m, i, j, S, self.data.shape[0])
+            return self.test(self.data, self.nx_skel, self.prt_m, i, j, S)
 
         i, j = (i, j) if (i < j) else (j, i)
         ijS_key = (i, j, frozenset(S), self.data_hash_key, self.ci_test_hash_key)

--- a/tests/TestMVPC_mv_fisherz.py
+++ b/tests/TestMVPC_mv_fisherz.py
@@ -46,8 +46,15 @@ class Test_test_wise_deletion_PC(unittest.TestCase):
         stop = timeit.default_timer()
         t_test_wise_pc = stop - start
 
-        print(f'Time comparison:\n pc: {t_pc}s, test-wise pc: {t_test_wise_pc}')
-        print(f'Result differences (0 means no difference between the results of different methods):\n pc and test-wise pc:{causal_graph_diff(cg_pc, cg_test_wise_pc)}')
+        print('Running MVPC')
+        start = timeit.default_timer()
+        cg_mvpc = pc(data, 0.05, mv_fisherz, True, 0,-1, True)  # Run PC and obtain the estimated graph (CausalGraph object)
+        stop = timeit.default_timer()
+        t_mvpc = stop - start
+
+        print(f'Time comparison:\n pc: {t_pc}s, test-wise pc: {t_test_wise_pc}, mvpc: {t_mvpc}')
+        print(f'Result differences (0 means no difference between the results of different methods):\n pc and test-wise pc: {causal_graph_diff(cg_pc, cg_test_wise_pc)}')
+        print(f'Result differences (0 means no difference between the results of different methods):\n pc and mvpc: {causal_graph_diff(cg_pc, cg_mvpc)}')
 
     def test_pc_with_mv_fisherz_MCAR_data(self):
         data_path = "data_linear_10.txt"
@@ -72,9 +79,15 @@ class Test_test_wise_deletion_PC(unittest.TestCase):
         stop = timeit.default_timer()
         t_test_wise_pc = stop - start
 
-        print(f'Time comparison:\n pc: {t_pc}s, test-wise pc: {t_test_wise_pc}')
-        print(f'Result differences (0 means no difference between the results of different methods):\n pc and test-wise pc:{causal_graph_diff(cg_pc, cg_test_wise_pc)}')
+        print('Running MVPC')
+        start = timeit.default_timer()
+        cg_mvpc = pc(mdata, 0.05, mv_fisherz, True, 0,-1, True)  # Run PC and obtain the estimated graph (CausalGraph object)
+        stop = timeit.default_timer()
+        t_mvpc = stop - start
 
+        print(f'Time comparison:\n pc: {t_pc}s, test-wise pc: {t_test_wise_pc}, mvpc: {t_mvpc}')
+        print(f'Result differences (0 means no difference between the results of different methods):\n pc and test-wise pc: {causal_graph_diff(cg_pc, cg_test_wise_pc)}')
+        print(f'Result differences (0 means no difference between the results of different methods):\n pc and mvpc: {causal_graph_diff(cg_pc, cg_mvpc)}')
         
     
     def test_pc_with_mv_fisherz_MCAR_data_assertion(self):
@@ -98,10 +111,10 @@ class Test_test_wise_deletion_PC(unittest.TestCase):
 if __name__ == '__main__':
     test = Test_test_wise_deletion_PC()
     print('------------------------------')
-    print('Test test-wise deletion PC on full datatsets.')
+    print('Test test-wise deletion PC and MVPC on full datatsets.')
     test.test_pc_with_mv_fisherz_full_data()
     print('------------------------------')
-    print('Test test-wise deletion PC on MCAR datatsets.')
+    print('Test test-wise deletion PC and MVPC on MCAR datatsets.')
     test.test_pc_with_mv_fisherz_MCAR_data()
     print('------------------------------')
     print('Test test-wise deletion PC on MCAR datatsets where most values are missing.')

--- a/tests/TestMVPC_mv_fisherz_test.py
+++ b/tests/TestMVPC_mv_fisherz_test.py
@@ -1,0 +1,167 @@
+import os
+import sys
+import timeit
+# get current directory
+path = os.getcwd()
+
+# get parent directory
+path=os.path.abspath(os.path.join(path, os.pardir))
+sys.path.append(path)
+
+import unittest
+import numpy as np
+from causallearn.utils.cit import fisherz, mv_fisherz
+
+
+class TestCIT_mv_fisherz(unittest.TestCase):
+    def test_chain(self):
+        mv_pvalues_t1 = []
+        pvalues_t1 = []
+        mv_pvalues_t2 = []
+        pvalues_t2 = []
+
+        for _ in range(100):
+            sz = 1000
+            data = np.zeros((sz, 3))
+
+            X = np.random.normal(0, 1.0, size=sz)
+            Z = 2 * X + 0.5 * np.random.normal(0, 1.0, size=sz)
+            Y = 0.5 * Z + 0.5 * np.random.normal(0, 1.0, size=sz)        
+            data[:, 0], data[:, 1], data[:, 2] = X, Y, Z
+            mdata = data.copy()
+
+            # X--> Z -->Y   
+            # Z -->R_Y   
+
+            mdata[Z > 0, 1] = np.nan
+
+            mv_pvalues_t1.append(mv_fisherz(mdata, 0, 1, ()))
+            pvalues_t1.append(fisherz(data, 0, 1, ()))
+            mv_pvalues_t2.append(mv_fisherz(mdata, 0, 1, (2,)))
+            pvalues_t2.append(fisherz(data, 0, 1, (2,)))
+
+        print('mv_fisherz: X and Y are not independent, pvalue is mean {:.3f}'.format(np.mean(mv_pvalues_t1)) + ' std: {:.3f}'.format(np.std(mv_pvalues_t1)))
+        print('fisherz: X and Y are not independent, pvalue is mean {:.3f}'.format(np.mean(pvalues_t1)) + ' std: {:.3f}'.format(np.std(pvalues_t1)))
+
+
+        print('mv_fisherz: X and Y are independent conditioning on Z, pvalue is mean {:.3f}'.format(np.mean(mv_pvalues_t2)) + ' std: {:.3f}'.format(np.std(mv_pvalues_t2)))
+        print('fisherz: X and Y are independent conditioning on Z, pvalue is mean {:.3f}'.format(np.mean(pvalues_t2)) + ' std: {:.3f}'.format(np.std(pvalues_t2)))
+
+    def test_confounder(self):
+        mv_pvalues_t1 = []
+        pvalues_t1 = []
+        mv_pvalues_t2 = []
+        pvalues_t2 = []
+
+        for _ in range(100):
+            sz = 1000
+            data = np.zeros((sz, 3))
+
+            Z = np.random.normal(0, 1.0, size=sz)
+            X = 2 * Z + 0.5 * np.random.normal(0, 1.0, size=sz)
+            Y = 0.5 * Z + 0.5 * np.random.normal(0, 1.0, size=sz)        
+            data[:, 0], data[:, 1], data[:, 2] = X, Y, Z
+            mdata = data.copy()
+
+            # X <-- Z -->Y   
+            # Z --> R_Y   
+
+            mdata[Z > 0, 1] = np.nan
+
+            mv_pvalues_t1.append(mv_fisherz(mdata, 0, 1, ()))
+            pvalues_t1.append(fisherz(data, 0, 1, ()))
+            mv_pvalues_t2.append(mv_fisherz(mdata, 0, 1, (2,)))
+            pvalues_t2.append(fisherz(data, 0, 1, (2,)))
+
+        print('mv_fisherz: X and Y are not independent, pvalue is mean {:.3f}'.format(np.mean(mv_pvalues_t1)) + ' std: {:.3f}'.format(np.std(mv_pvalues_t1)))
+        print('fisherz: X and Y are not independent, pvalue is mean {:.3f}'.format(np.mean(pvalues_t1)) + ' std: {:.3f}'.format(np.std(pvalues_t1)))
+
+
+        print('mv_fisherz: X and Y are independent conditioning on Z, pvalue is mean {:.3f}'.format(np.mean(mv_pvalues_t2)) + ' std: {:.3f}'.format(np.std(mv_pvalues_t2)))
+        print('fisherz: X and Y are independent conditioning on Z, pvalue is mean {:.3f}'.format(np.mean(pvalues_t2)) + ' std: {:.3f}'.format(np.std(pvalues_t2)))
+
+    def test_fork(self):
+        mv_pvalues_t1 = []
+        pvalues_t1 = []
+        mv_pvalues_t2 = []
+        pvalues_t2 = []
+
+        for _ in range(100):
+            sz = 1000
+            data = np.zeros((sz, 3))
+
+            X = np.random.normal(0, 1.0, size=sz)
+            Y = np.random.normal(0, 1.0, size=sz)
+            Z = 0.5 * X + 0.5 * Y + 0.5 * np.random.normal(0, 1.0, size=sz)        
+            data[:, 0], data[:, 1], data[:, 2] = X, Y, Z
+            mdata = data.copy()
+
+            # X--> Z <--Y   
+            # Z --> R_Y   
+
+            mdata[Z > 0, 1] = np.nan
+
+            mv_pvalues_t1.append(mv_fisherz(mdata, 0, 1, ()))
+            pvalues_t1.append(fisherz(data, 0, 1, ()))
+            mv_pvalues_t2.append(mv_fisherz(mdata, 0, 1, (2,)))
+            pvalues_t2.append(fisherz(data, 0, 1, (2,)))
+
+        print('mv_fisherz: X and Y are independent, pvalue is mean {:.3f}'.format(np.mean(mv_pvalues_t1)) + ' std: {:.3f}'.format(np.std(mv_pvalues_t1)))
+        print('fisherz: X and Y are independent, pvalue is mean {:.3f}'.format(np.mean(pvalues_t1)) + ' std: {:.3f}'.format(np.std(pvalues_t1)))
+
+        print('mv_fisherz: X and Y are not independent conditioning on Z, pvalue is mean {:.3f}'.format(np.mean(mv_pvalues_t2)) + ' std: {:.3f}'.format(np.std(mv_pvalues_t2)))
+        print('fisherz: X and Y are not independent conditioning on Z, pvalue is mean {:.3f}'.format(np.mean(pvalues_t2)) + ' std: {:.3f}'.format(np.std(pvalues_t2)))
+
+    def test_fork2(self):
+        mv_pvalues_t1 = []
+        pvalues_t1 = []
+        mv_pvalues_t2 = []
+        pvalues_t2 = []
+
+        for _ in range(100):
+            sz = 1000
+            data = np.zeros((sz, 3))
+
+            X = np.random.normal(0, 1.0, size=sz)
+            Y = np.random.normal(0, 1.0, size=sz)
+            Z = 0.5 * X + 0.5 * Y + 0.5 * np.random.normal(0, 1.0, size=sz)        
+            data[:, 0], data[:, 1], data[:, 2] = X, Y, Z
+            mdata = data.copy()
+
+            # X--> Z <--Y   
+            # Z --> R_Y   
+
+            mdata[Y > 0, 2] = np.nan
+
+            mv_pvalues_t1.append(mv_fisherz(mdata, 0, 1, ()))
+            pvalues_t1.append(fisherz(data, 0, 1, ()))
+            mv_pvalues_t2.append(mv_fisherz(mdata, 0, 1, (2,)))
+            pvalues_t2.append(fisherz(data, 0, 1, (2,)))
+
+        print('mv_fisherz: X and Y are independent, pvalue is mean {:.3f}'.format(np.mean(mv_pvalues_t1)) + ' std: {:.3f}'.format(np.std(mv_pvalues_t1)))
+        print('fisherz: X and Y are independent, pvalue is mean {:.3f}'.format(np.mean(pvalues_t1)) + ' std: {:.3f}'.format(np.std(pvalues_t1)))
+
+        print('mv_fisherz: X and Y are not independent conditioning on Z, pvalue is mean {:.3f}'.format(np.mean(mv_pvalues_t2)) + ' std: {:.3f}'.format(np.std(mv_pvalues_t2)))
+        print('fisherz: X and Y are not independent conditioning on Z, pvalue is mean {:.3f}'.format(np.mean(pvalues_t2)) + ' std: {:.3f}'.format(np.std(pvalues_t2)))
+
+
+
+        
+
+if __name__ == '__main__':
+    test = TestCIT_mv_fisherz()
+    print('------------------------------')
+    print('Test mv_fisherz() with the chain structure: X->Z->Y, Z -> R_Y')
+    test.test_chain()
+    print('------------------------------')
+    print('Test mv_fisherz() with the confounder structure: X<-Z->Y, Z -> R_Y')
+    test.test_confounder()
+    print('------------------------------')
+    print('Test mv_fisherz() with the fork structure: X->Z<-Y, Z -> R_Y')
+    print('In theory, the test-wise deletion test on this graph structure leads to wrong results.')
+    test.test_fork()
+    print('------------------------------')
+    print('Test mv_fisherz() with the fork structure: X->Z<-Y, Y -> R_Z')
+    print('In theory, the test-wise deletion test on this graph structure has no problem.')
+    test.test_fork2()
+    


### PR DESCRIPTION
# Updated functions
__mv_fisherz():__
1. update the function such that it calls fisherz() test instead of copying from fisherz(); 
2. remove the redundent parameter sample_size. 

__mc_finsherz():__ 
1. remove the redundent parameter samples_size. 

__get_index_mv_row():__ 
1. rename it as get_index_no_mv_row(), because it actually gets the rows without missing values.

# Testing
__TestMVPC_mv_fisherz_test.py__
* test the independence test on different graph structures for 100 times, i.e., chain, fork, and confounding structures. By comparing with fisherz() on complete data, we know the correctness of 
* In theory, the fork structure can lead to wrong results of mv_fisherz(), which is also included in the test.
![Screenshot 2022-06-22 at 11 25 45](https://user-images.githubusercontent.com/22346392/174997208-32d89269-2c40-4598-a3fa-1c6ee73dd4e1.png)

__TestMVPC_mv_fisherz.py__
* Since MVPC also applies mv_fisherz(), the test also includes mvpc and compares with pc. 
![Screenshot 2022-06-22 at 11 24 45](https://user-images.githubusercontent.com/22346392/174997284-51e06730-d5cb-41b6-b96d-28060903d804.png)
![Screenshot 2022-06-22 at 11 25 01](https://user-images.githubusercontent.com/22346392/174997302-db8d47b4-0f73-4bb5-a485-337133fa4bf4.png)


