### PR TITLE
Fix cit.chisq big memory bug

### DIFF
--- a/causallearn/utils/cit.py
+++ b/causallearn/utils/cit.py
@@ -6,6 +6,8 @@ from scipy.stats import chi2, norm
 from causallearn.utils.KCI.KCI import KCI_CInd, KCI_UInd
 from causallearn.utils.PCUtils import Helper
 
+CONST_BINCOUNT_UNIQUE_THRESHOLD = 1e5
+
 
 def kci(data, X, Y, condition_set=None, kernelX='Gaussian', kernelY='Gaussian', kernelZ='Gaussian',
         est_width='empirical', polyd=2, kwidthx=None, kwidthy=None, kwidthz=None):
@@ -223,7 +225,7 @@ def chisq_or_gsq_test(dataSXY, cardSXY, G_sq=False):
         yMarginalCounts = np.sum(xyJointCounts, axis=0)
         return xyJointCounts, xMarginalCounts, yMarginalCounts
 
-    def _Fill3DCountTable_by_bincount(dataSXY, cardSXY):
+    def _Fill3DCountTableByBincount(dataSXY, cardSXY):
         cardX, cardY = cardSXY[-2:]
         cardS = np.prod(cardSXY[:-2])
         cardCumProd = np.ones_like(cardSXY)
@@ -240,7 +242,7 @@ def chisq_or_gsq_test(dataSXY, cardSXY, G_sq=False):
         SyJointCounts = np.sum(SxyJointCounts, axis=1)
         return SxyJointCounts, SMarginalCounts, SxJointCounts, SyJointCounts
 
-    def _Fill3DCountTable_by_unique(dataSXY, cardSXY):
+    def _Fill3DCountTableByUnique(dataSXY, cardSXY):
         # Sometimes when the conditioning set contains many variables and each variable's cardinality is large
         # e.g. consider an extreme case where
         # S contains 7 variables and each's cardinality=20, then cardS = np.prod(cardSXY[:-2]) would be 1280000000
@@ -271,8 +273,8 @@ def chisq_or_gsq_test(dataSXY, cardSXY, G_sq=False):
     def _Fill3DCountTable(dataSXY, cardSXY):
         # about the threshold 1e5, see a rough performance example at:
         # https://gist.github.com/MarkDana/e7d9663a26091585eb6882170108485e#file-count-unique-in-array-performance-md
-        if np.prod(cardSXY) < 1e5: return _Fill3DCountTable_by_bincount(dataSXY, cardSXY)
-        return _Fill3DCountTable_by_unique(dataSXY, cardSXY)
+        if np.prod(cardSXY) < CONST_BINCOUNT_UNIQUE_THRESHOLD: return _Fill3DCountTableByBincount(dataSXY, cardSXY)
+        return _Fill3DCountTableByUnique(dataSXY, cardSXY)
 
     def _CalculatePValue(cTables, eTables):
         """

--- a/causallearn/utils/cit.py
+++ b/causallearn/utils/cit.py
@@ -197,7 +197,6 @@ def chisq_or_gsq_test(dataSXY, cardSXY, G_sq=False):
     cardSXY: cardinalities of each row (each variable)
     G_sq: True if use G-sq, otherwise (False by default), use Chi_sq
     """
-
     def _Fill2DCountTable(dataXY, cardXY):
         """
         e.g. dataXY: the observed dataset contains 5 samples, on variable x and y they're
@@ -224,16 +223,14 @@ def chisq_or_gsq_test(dataSXY, cardSXY, G_sq=False):
         yMarginalCounts = np.sum(xyJointCounts, axis=0)
         return xyJointCounts, xMarginalCounts, yMarginalCounts
 
-    def _Fill3DCountTable(dataSXY, cardSXY):
+    def _Fill3DCountTable_by_bincount(dataSXY, cardSXY):
         cardX, cardY = cardSXY[-2:]
         cardS = np.prod(cardSXY[:-2])
-
         cardCumProd = np.ones_like(cardSXY)
         cardCumProd[:-1] = np.cumprod(cardSXY[1:][::-1])[::-1]
         SxyIndexed = np.dot(cardCumProd[None], dataSXY)[0]
 
         SxyJointCounts = np.bincount(SxyIndexed, minlength=cardS * cardX * cardY).reshape((cardS, cardX, cardY))
-
         SMarginalCounts = np.sum(SxyJointCounts, axis=(1, 2))
         SMarginalCountsNonZero = SMarginalCounts != 0
         SMarginalCounts = SMarginalCounts[SMarginalCountsNonZero]
@@ -242,6 +239,40 @@ def chisq_or_gsq_test(dataSXY, cardSXY, G_sq=False):
         SxJointCounts = np.sum(SxyJointCounts, axis=2)
         SyJointCounts = np.sum(SxyJointCounts, axis=1)
         return SxyJointCounts, SMarginalCounts, SxJointCounts, SyJointCounts
+
+    def _Fill3DCountTable_by_unique(dataSXY, cardSXY):
+        # Sometimes when the conditioning set contains many variables and each variable's cardinality is large
+        # e.g. consider an extreme case where
+        # S contains 7 variables and each's cardinality=20, then cardS = np.prod(cardSXY[:-2]) would be 1280000000
+        # i.e., there are 1280000000 different possible combinations of S,
+        #    so the SxyJointCounts array would be of size 1280000000 * cardX * cardY * np.int64,
+        #    i.e., ~3.73TB memory! (suppose cardX, cardX are also 20)
+        # However, samplesize is usually in 1k-100k scale, far less than cardS,
+        # i.e., not all (and actually only a very small portion of combinations of S appeared in data)
+        #    i.e., SMarginalCountsNonZero in _Fill3DCountTable_by_bincount is a very sparse array
+        # So when cardSXY is large, we first re-index S (skip the absent combinations) and then count XY table for each.
+        # See https://github.com/cmu-phil/causal-learn/pull/37.
+        cardX, cardY = cardSXY[-2:]
+        cardSs = cardSXY[:-2]
+
+        cardSsCumProd = np.ones_like(cardSs)
+        cardSsCumProd[:-1] = np.cumprod(cardSs[1:][::-1])[::-1]
+        SIndexed = np.dot(cardSsCumProd[None], dataSXY[:-2])[0]
+
+        uniqSIndices, inverseSIndices, SMarginalCounts = np.unique(SIndexed, return_counts=True, return_inverse=True)
+        cardS_reduced = len(uniqSIndices)
+        SxyIndexed = inverseSIndices * cardX * cardY + dataSXY[-2] * cardY + dataSXY[-1]
+        SxyJointCounts = np.bincount(SxyIndexed, minlength=cardS_reduced * cardX * cardY).reshape((cardS_reduced, cardX, cardY))
+
+        SxJointCounts = np.sum(SxyJointCounts, axis=2)
+        SyJointCounts = np.sum(SxyJointCounts, axis=1)
+        return SxyJointCounts, SMarginalCounts, SxJointCounts, SyJointCounts
+
+    def _Fill3DCountTable(dataSXY, cardSXY):
+        # about the threshold 1e5, see a rough performance example at:
+        # https://gist.github.com/MarkDana/e7d9663a26091585eb6882170108485e#file-count-unique-in-array-performance-md
+        if np.prod(cardSXY) < 1e5: return _Fill3DCountTable_by_bincount(dataSXY, cardSXY)
+        return _Fill3DCountTable_by_unique(dataSXY, cardSXY)
 
     def _CalculatePValue(cTables, eTables):
         """
@@ -280,10 +311,10 @@ def chisq_or_gsq_test(dataSXY, cardSXY, G_sq=False):
         xyJointCounts, xMarginalCounts, yMarginalCounts = _Fill2DCountTable(dataSXY, cardSXY)
         xyExpectedCounts = np.outer(xMarginalCounts, yMarginalCounts) / dataSXY.shape[1]  # divide by sample size
         return _CalculatePValue(xyJointCounts[None], xyExpectedCounts[None])
+
     # else, S is not empty: conditioning
     SxyJointCounts, SMarginalCounts, SxJointCounts, SyJointCounts = _Fill3DCountTable(dataSXY, cardSXY)
     SxyExpectedCounts = SxJointCounts[:, :, None] * SyJointCounts[:, None, :] / SMarginalCounts[:, None, None]
-
     return _CalculatePValue(SxyJointCounts, SxyExpectedCounts)
 
 


### PR DESCRIPTION
### Updated functions:
`chisq_or_gsq_test` in `utils/cit.py`.

### What is improved:
 - When conditioning set and cardinalities are large: both **speed** and **memory usage** get better.
 - When conditioning set and cardinalities are small: same as before.

### Why this update is needed:
Consider a chi-squared CITest over discrete variables `X` and `Y` given conditioning variables set `S`. We'll need to count the joint probability table over each occurred configuration of `S`. In pull request #6, we parallelize this counting cells process and gain huge speedup. However, that implementation is based on an assumption that the cardinalities of variables are usually small (e.g. <5), and the size of `S` is usually small (e.g. <5).

Yet sometimes the conditioning set may contain many variables and each variable's cardinality is large. Consider a case where `S` contains 7 variables and each's cardinality=20, then `cardS = np.prod(cardSXY[:-2])` would be 1280000000, i.e., there are 1280000000 different possible configuration of `S`, so the `SxyJointCounts` ([to the line](https://github.com/cmu-phil/causal-learn/blob/388d39bd2ce51f577d1803d2b165acc6ab61e4b8/causallearn/utils/cit.py#L235)) array would be of size `1280000000 * cardX * cardY * np.int64`, i.e., ~3.73TB memory! (suppose `cardX`, `cardY` are also 20).

However, the sample size is usually in 1k-100k scale, which is far less than `cardS`. Not all (and actually only a very small portion of configurations of `S` appeared in data), i.e., `SMarginalCountsNonZero` ([to the line](https://github.com/cmu-phil/causal-learn/blob/388d39bd2ce51f577d1803d2b165acc6ab61e4b8/causallearn/utils/cit.py#L238)) is a very sparse array.

Hence, when `cardSXY` is large, we first re-index `S` (skip the absent configurations) and then count the joint XY table for each configuration. Specifically, two functions `_Fill3DCountTable_by_bincount` and `_Fill3DCountTable_by_unique` are used under different scale of `cardSXY`.

### Testing:
- Code:
```python
from causallearn.utils.cit_new import chisq as chisq_new
from causallearn.utils.cit_old import chisq as chisq_old
import time, tracemalloc

data = np.random.randint(0, 20, (8, 20000))
X, Y = 0, 1
S = tuple(range(2, 8))
# S contains 6 variables. Each has a cardinality of 20.

tracemalloc.start()
tic = time.time()
p_new = chisq_new(data, X, Y, S)
tac = time.time()
_, peak_new = tracemalloc.get_traced_memory()
tracemalloc.stop()
print(f'new: used {tac - tic:}s, peak memory {peak_new / 1024 ** 2} MiB')

tracemalloc.start()
tic = time.time()
p_old = chisq_old(data, X, Y, S)
tac = time.time()
_, peak_old = tracemalloc.get_traced_memory()
tracemalloc.stop()
print(f'old: used {tac - tic:}s, peak memory {peak_old / 1024 ** 2} MiB')

assert p_old == p_new
```
 - Results (on Apple M1 Max):
```
new: used 0.0003800392150878906s, peak memory 0.307403564453125 MiB
old: used 11.38077425956726s, peak memory 70793.66288280487 MiB
```

### Empirical threshold: how to choose between `np.bincount` and `np.unique`?
Refer [here](https://gist.github.com/MarkDana/e7d9663a26091585eb6882170108485e#file-count-unique-in-array-performance-md):

![time](https://user-images.githubusercontent.com/42901288/175042682-1c79136f-a66a-4fc8-9496-5140b4a30a6c.png)
![memory](https://user-images.githubusercontent.com/42901288/175042701-7db6009f-5180-41b2-9a5d-ecd33999183f.png)
