### PR TITLE
Rewrite CITests as a class && re-use covariance matrix for fisherz

### DIFF
--- a/causallearn/search/ConstraintBased/CDNOD.py
+++ b/causallearn/search/ConstraintBased/CDNOD.py
@@ -13,9 +13,9 @@ from causallearn.utils.cit import *
 from causallearn.search.ConstraintBased.PC import get_parent_missingness_pairs, skeleton_correction
 
 
-def cdnod(data: ndarray, c_indx: ndarray, alpha: float = 0.05, indep_test: str = fisherz, stable: bool = True,
-          uc_rule: int = 0, uc_priority: int = 2, mvcdnod: bool = False, correction_name: str = 'MV_Crtn_Fisher_Z',
-          background_knowledge: Optional[BackgroundKnowledge] = None, verbose: bool = False,
+def cdnod(data: ndarray, c_indx: ndarray, alpha: float=0.05, indep_test: str=fisherz, stable: bool=True,
+          uc_rule: int=0, uc_priority: int=2, mvcdnod: bool=False, correction_name: str='MV_Crtn_Fisher_Z',
+          background_knowledge: Optional[BackgroundKnowledge]=None, verbose: bool=False,
           show_progress: bool = True) -> CausalGraph:
     """
     Causal discovery from nonstationary/heterogeneous data

--- a/causallearn/search/ConstraintBased/PC.py
+++ b/causallearn/search/ConstraintBased/PC.py
@@ -6,6 +6,7 @@ from itertools import combinations, permutations
 from typing import Dict, List, Tuple
 
 import networkx as nx
+import numpy as np
 from numpy import ndarray
 
 from causallearn.graph.GraphClass import CausalGraph
@@ -34,8 +35,7 @@ def pc(
         warnings.warn("The number of features is much larger than the sample size!")
 
     if mvpc:  # missing value PC
-        if indep_test == fisherz:
-            indep_test = mv_fisherz
+        if indep_test == fisherz: indep_test = mv_fisherz
         return mvpc_alg(data=data, node_names=node_names, alpha=alpha, indep_test=indep_test, correction_name=correction_name, stable=stable,
                         uc_rule=uc_rule, uc_priority=uc_priority, background_knowledge=background_knowledge,
                         verbose=verbose,
@@ -48,11 +48,11 @@ def pc(
 
 def pc_alg(
     data: ndarray,
-    node_names: List[str] | None, 
-    alpha: float, 
-    indep_test, 
-    stable: bool, 
-    uc_rule: int, 
+    node_names: List[str] | None,
+    alpha: float,
+    indep_test: str,
+    stable: bool,
+    uc_rule: int,
     uc_priority: int,
     background_knowledge: BackgroundKnowledge | None = None,
     verbose: bool = False,
@@ -66,12 +66,12 @@ def pc_alg(
     data : data set (numpy ndarray), shape (n_samples, n_features). The input data, where n_samples is the number of samples and n_features is the number of features.
     node_names: Shape [n_features]. The name for each feature (each feature is represented as a Node in the graph, so it's also the node name)
     alpha : float, desired significance level of independence tests (p_value) in (0, 1)
-    indep_test : the function of the independence test being used
-            [fisherz, chisq, gsq, kci]
-           - fisherz: Fisher's Z conditional independence test
-           - chisq: Chi-squared conditional independence test
-           - gsq: G-squared conditional independence test
-           - kci: Kernel-based conditional independence test
+    indep_test : str, the name of the independence test being used
+            ["fisherz", "chisq", "gsq", "kci"]
+           - "fisherz": Fisher's Z conditional independence test
+           - "chisq": Chi-squared conditional independence test
+           - "gsq": G-squared conditional independence test
+           - "kci": Kernel-based conditional independence test
     stable : run stabilized skeleton discovery if True (default = True)
     uc_rule : how unshielded colliders are oriented
            0: run uc_sepset
@@ -97,6 +97,7 @@ def pc_alg(
     """
 
     start = time.time()
+    indep_test = CIT(data, indep_test)
     cg_1 = SkeletonDiscovery.skeleton_discovery(data, alpha, indep_test, stable,
                                                 background_knowledge=background_knowledge, verbose=verbose,
                                                 show_progress=show_progress, node_names=node_names)
@@ -135,14 +136,14 @@ def pc_alg(
 
 
 def mvpc_alg(
-    data: ndarray, 
-    node_names: List[str] | None, 
-    alpha: float, 
-    indep_test, 
-    correction_name: str, 
-    stable: bool, 
+    data: ndarray,
+    node_names: List[str] | None,
+    alpha: float,
+    indep_test: str,
+    correction_name: str,
+    stable: bool,
     uc_rule: int,
-    uc_priority: int, 
+    uc_priority: int,
     background_knowledge: BackgroundKnowledge | None = None,
     verbose: bool = False,
     show_progress: bool = True,
@@ -155,8 +156,8 @@ def mvpc_alg(
     data : data set (numpy ndarray), shape (n_samples, n_features). The input data, where n_samples is the number of samples and n_features is the number of features.
     node_names: Shape [n_features]. The name for each feature (each feature is represented as a Node in the graph, so it's also the node name)
     alpha :  float, desired significance level of independence tests (p_value) in (0,1)
-    indep_test : name of the test-wise deletion independence test being used
-            [mv_fisherz, mv_g_sq]
+    indep_test : str, name of the test-wise deletion independence test being used
+            ["mv_fisherz", "mv_g_sq"]
             - mv_fisherz: Fisher's Z conditional independence test
             - mv_g_sq: G-squared conditional independence test (TODO: under development)
     correction_name : correction_name: name of the missingness correction
@@ -190,7 +191,7 @@ def mvpc_alg(
     """
 
     start = time.time()
-
+    indep_test = CIT(data, indep_test)
     ## Step 1: detect the direct causes of missingness indicators
     prt_m = get_parent_missingness_pairs(data, alpha, indep_test, stable)
     # print('Finish detecting the parents of missingness indicators.  ')
@@ -329,9 +330,7 @@ def detect_parent(r: int, data_: ndarray, alpha: float, indep_test, stable: bool
 
     no_of_var = data.shape[1]
     cg = CausalGraph(no_of_var)
-    cg.data = data
-    cg.set_ind_test(indep_test)
-    cg.corr_mat = np.corrcoef(data, rowvar=False) if indep_test == fisherz else []
+    cg.set_ind_test(CIT(data, indep_test.method))
 
     node_ids = range(no_of_var)
     pair_of_variables = list(permutations(node_ids, 2))
@@ -427,11 +426,9 @@ def skeleton_correction(data: ndarray, alpha: float, test_with_correction_name: 
     ## Initialize the graph with the result of test-wise deletion skeletion search
     cg = init_cg
 
-    cg.data = data
     if test_with_correction_name in ["MV_Crtn_Fisher_Z", "MV_Crtn_G_sq"]:
-        cg.set_ind_test(mc_fisherz, True)
+        cg.set_ind_test(CIT(data, "mc_fisherz"))
     # No need of the correlation matrix if using test-wise deletion test
-    cg.corr_mat = np.corrcoef(data, rowvar=False) if test_with_correction_name == "MV_Crtn_Fisher_Z" else []
     cg.prt_m = prt_m
     ## *********** Adaption 1 ***********
 

--- a/causallearn/search/ConstraintBased/PC.py
+++ b/causallearn/search/ConstraintBased/PC.py
@@ -35,7 +35,8 @@ def pc(
         warnings.warn("The number of features is much larger than the sample size!")
 
     if mvpc:  # missing value PC
-        if indep_test == fisherz: indep_test = mv_fisherz
+        if indep_test == fisherz:
+            indep_test = mv_fisherz
         return mvpc_alg(data=data, node_names=node_names, alpha=alpha, indep_test=indep_test, correction_name=correction_name, stable=stable,
                         uc_rule=uc_rule, uc_priority=uc_priority, background_knowledge=background_knowledge,
                         verbose=verbose,

--- a/causallearn/utils/cit.py
+++ b/causallearn/utils/cit.py
@@ -7,436 +7,451 @@ from causallearn.utils.KCI.KCI import KCI_CInd, KCI_UInd
 from causallearn.utils.PCUtils import Helper
 
 CONST_BINCOUNT_UNIQUE_THRESHOLD = 1e5
+fisherz = "fisherz"
+mv_fisherz = "mv_fisherz"
+mc_fisherz = "mc_fisherz"
+kci = "kci"
+chisq = "chisq"
+gsq = "gsq"
 
-
-def kci(data, X, Y, condition_set=None, kernelX='Gaussian', kernelY='Gaussian', kernelZ='Gaussian',
-        est_width='empirical', polyd=2, kwidthx=None, kwidthy=None, kwidthz=None):
-    if condition_set is None or len(condition_set) < 1:
-        return kci_ui(data[np.ix_(range(data.shape[0]), [X])], data[np.ix_(range(data.shape[0]), [Y])],
-                      kernelX, kernelY, est_width, polyd, kwidthx, kwidthy)
-    else:
-        return kci_ci(data[np.ix_(range(data.shape[0]), [X])], data[np.ix_(range(data.shape[0]), [Y])],
-                      data[np.ix_(range(data.shape[0]), list(condition_set))],
-                      kernelX, kernelY, kernelZ, est_width, polyd, kwidthx, kwidthy, kwidthz)
-
-
-def kci_ui(X, Y, kernelX='Gaussian', kernelY='Gaussian', est_width='empirical', polyd=2, kwidthx=None, kwidthy=None):
-    """
-     To test if x and y are unconditionally independent
-       Parameters
-       ----------
-       kernelX: kernel function for input data x
-           'Gaussian': Gaussian kernel
-           'Polynomial': Polynomial kernel
-           'Linear': Linear kernel
-       kernelY: kernel function for input data y
-       est_width: set kernel width for Gaussian kernels
-           'empirical': set kernel width using empirical rules (default)
-           'median': set kernel width using the median trick
-       polyd: polynomial kernel degrees (default=2)
-       kwidthx: kernel width for data x (standard deviation sigma)
-       kwidthy: kernel width for data y (standard deviation sigma)
-    """
-
-    kci_uind = KCI_UInd(kernelX, kernelY, est_width=est_width, polyd=polyd, kwidthx=kwidthx, kwidthy=kwidthy)
-    pvalue, _ = kci_uind.compute_pvalue(X, Y)
-    return pvalue
-
-
-def kci_ci(X, Y, Z, kernelX='Gaussian', kernelY='Gaussian', kernelZ='Gaussian', est_width='empirical', polyd=2,
-           kwidthx=None, kwidthy=None, kwidthz=None):
-    """
-     To test if x and y are conditionally independent given z
-       Parameters
-       ----------
-       kernelX: kernel function for input data x
-           'Gaussian': Gaussian kernel
-           'Polynomial': Polynomial kernel
-           'Linear': Linear kernel
-       kernelY: kernel function for input data y
-       kernelZ: kernel function for input data z
-       est_width: set kernel width for Gaussian kernels
-           'empirical': set kernel width using empirical rules (default)
-           'median': set kernel width using the median trick
-       polyd: polynomial kernel degrees (default=2)
-       kwidthx: kernel width for data x (standard deviation sigma, default None)
-       kwidthy: kernel width for data y (standard deviation sigma)
-       kwidthz: kernel width for data y (standard deviation sigma)
-    """
-
-    kci_cind = KCI_CInd(kernelX, kernelY, kernelZ, est_width=est_width, polyd=polyd, kwidthx=kwidthx, kwidthy=kwidthy,
-                        kwidthz=kwidthz)
-    pvalue, _ = kci_cind.compute_pvalue(X, Y, Z)
-    return pvalue
-
-
-def mv_fisherz(mvdata, X, Y, condition_set):
-    """
-    Perform an independence test using Fisher-Z's test for data with missing values
-
-    Parameters
-    ----------
-    mvdata : data with missing values
-    X, Y and condition_set : column indices of data
-
-    Returns
-    -------
-    p : the p-value of the test
-    """
-    var = list((X, Y) + condition_set)
-    test_wise_deletion_XYcond_rows_index = get_index_no_mv_rows(mvdata[:, var])
-    assert len(test_wise_deletion_XYcond_rows_index) != 0, "A test-wise deletion fisher-z test appears no overlapping data of involved variables. Please check the input data."
-    test_wise_deleted_data = mvdata[test_wise_deletion_XYcond_rows_index,:]
-    return fisherz(test_wise_deleted_data, X, Y, condition_set)
-
-
-def mc_fisherz(mdata, skel, prt_m, X, Y, condition_set):
-    """Perform an independent test using Fisher-Z's test with test-wise deletion and missingness correction
-    If it is not the case which requires a correction, then call function mvfisherZ(...)
-    :param prt_m: dictionary, with elements:
-        - m: missingness indicators which are not MCAR
-        - prt: parents of the missingness indicators
-    """
-
-    ## Check whether whether there is at least one common child of X and Y
-    if not Helper.cond_perm_c(X, Y, condition_set, prt_m, skel):
-        return mv_fisherz(mdata, X, Y, condition_set)
-
-    ## *********** Step 1 ***********
-    # Learning generaive model for {X, Y, S} to impute X, Y, and S
-
-    ## Get parents the {xyS} missingness indicators with parents: prt_m
-    # W is the variable which can be used for missingness correction
-    W_indx_ = Helper.get_prt_mvars(var=list((X, Y) + condition_set), prt_m=prt_m)
-
-    if len(W_indx_) == 0:  # When there is no variable can be used for correction
-        return mv_fisherz(mdata, X, Y, condition_set)
-
-    ## Get the parents of W missingness indicators
-    W_indx = Helper.get_prt_mw(W_indx_, prt_m)
-
-    ## Prepare the W for regression
-    # Since the XYS will be regressed on W,
-    # W will not contain any of XYS
-    var = list((X, Y) + condition_set)
-    W_indx = list(set(W_indx) - set(var))
-
-    if len(W_indx) == 0:  # When there is no variable can be used for correction
-        return mv_fisherz(mdata, X, Y, condition_set)
-
-    ## Learn regression models with test-wise deleted data
-    involve_vars = var + W_indx
-    tdel_data = Helper.test_wise_deletion(mdata[:, involve_vars])
-    effective_sz = len(tdel_data[:, 0])
-    regMs, rss = Helper.learn_regression_model(tdel_data, num_model=len(var))
-
-    ## *********** Step 2 ***********
-    # Get the data of the predictors, Ws
-    # The sample size of Ws is the same as the effective sample size
-    Ws = Helper.get_predictor_ws(mdata[:, involve_vars], num_test_var=len(var), effective_sz=effective_sz)
-
-    ## *********** Step 3 ***********
-    # Generate the virtual data follows the full data distribution P(X, Y, S)
-    # The sample size of data_vir is the same as the effective sample size
-    data_vir = Helper.gen_vir_data(regMs, rss, Ws, len(var), effective_sz)
-
-    if len(var) > 2:
-        cond_set_bgn_0 = np.arange(2, len(var))
-    else:
-        cond_set_bgn_0 = []
-
-    return mv_fisherz(data_vir, 0, 1, tuple(cond_set_bgn_0))
-
-
-def fisherz(data, X, Y, condition_set, correlation_matrix=None):
-    """
-    Perform an independence test using Fisher-Z's test
-
-    Parameters
-    ----------
-    data : data matrices
-    X, Y and condition_set : column indices of data
-    correlation_matrix : correlation matrix; 
-                         None means without the parameter of correlation matrix
-
-    Returns
-    -------
-    p : the p-value of the test
-    """
-    if correlation_matrix is None:
-        correlation_matrix = np.corrcoef(data.T)
-    sample_size = data.shape[0]
-    var = list((X, Y) + condition_set)
-    sub_corr_matrix = correlation_matrix[np.ix_(var, var)]
-    inv = np.linalg.inv(sub_corr_matrix)
-    r = -inv[0, 1] / sqrt(inv[0, 0] * inv[1, 1])
-    Z = 0.5 * log((1 + r) / (1 - r))
-    X = sqrt(sample_size - len(condition_set) - 3) * abs(Z)
-    p = 2 * (1 - norm.cdf(abs(X)))
-    return p
-
-
-def chisq(data, X, Y, conditioning_set, cardinalities=None):
-    # though cardinalities can be computed from data, here we pass it as argument,
-    # to prevent from repeated computation on each variable's vardinality
-    if cardinalities is None: cardinalities = np.max(data, axis=0) + 1
-    indexs = list(conditioning_set) + [X, Y]
-    return chisq_or_gsq_test(data[:, indexs].T, cardinalities[indexs])
-
-
-def gsq(data, X, Y, conditioning_set, cardinalities=None):
-    if cardinalities is None: cardinalities = np.max(data, axis=0) + 1
-    indexs = list(conditioning_set) + [X, Y]
-    return chisq_or_gsq_test(data[:, indexs].T, cardinalities[indexs], G_sq=True)
-
-
-def chisq_or_gsq_test(dataSXY, cardSXY, G_sq=False):
-    """by Haoyue@12/18/2021
-    Parameters
-    ----------
-    dataSXY: numpy.ndarray, in shape (|S|+2, n), where |S| is size of conditioning set (can be 0), n is sample size
-             dataSXY.dtype = np.int64, and each row has values [0, 1, 2, ..., card_of_this_row-1]
-    cardSXY: cardinalities of each row (each variable)
-    G_sq: True if use G-sq, otherwise (False by default), use Chi_sq
-    """
-    def _Fill2DCountTable(dataXY, cardXY):
-        """
-        e.g. dataXY: the observed dataset contains 5 samples, on variable x and y they're
-            x: 0 1 2 3 0
-            y: 1 0 1 2 1
-        cardXY: [4, 3]
-        fill in the counts by index, we have the joint count table in 4 * 3:
-            xy| 0 1 2
-            --|-------
-            0 | 0 2 0
-            1 | 1 0 0
-            2 | 0 1 0
-            3 | 0 0 1
-        note: if sample size is large enough, in theory:
-                min(dataXY[i]) == 0 && max(dataXY[i]) == cardXY[i] - 1
-            however some values may be missed.
-            also in joint count, not every value in [0, cardX * cardY - 1] occurs.
-            that's why we pass cardinalities in, and use `minlength=...` in bincount
-        """
-        cardX, cardY = cardXY
-        xyIndexed = dataXY[0] * cardY + dataXY[1]
-        xyJointCounts = np.bincount(xyIndexed, minlength=cardX * cardY).reshape(cardXY)
-        xMarginalCounts = np.sum(xyJointCounts, axis=1)
-        yMarginalCounts = np.sum(xyJointCounts, axis=0)
-        return xyJointCounts, xMarginalCounts, yMarginalCounts
-
-    def _Fill3DCountTableByBincount(dataSXY, cardSXY):
-        cardX, cardY = cardSXY[-2:]
-        cardS = np.prod(cardSXY[:-2])
-        cardCumProd = np.ones_like(cardSXY)
-        cardCumProd[:-1] = np.cumprod(cardSXY[1:][::-1])[::-1]
-        SxyIndexed = np.dot(cardCumProd[None], dataSXY)[0]
-
-        SxyJointCounts = np.bincount(SxyIndexed, minlength=cardS * cardX * cardY).reshape((cardS, cardX, cardY))
-        SMarginalCounts = np.sum(SxyJointCounts, axis=(1, 2))
-        SMarginalCountsNonZero = SMarginalCounts != 0
-        SMarginalCounts = SMarginalCounts[SMarginalCountsNonZero]
-        SxyJointCounts = SxyJointCounts[SMarginalCountsNonZero]
-
-        SxJointCounts = np.sum(SxyJointCounts, axis=2)
-        SyJointCounts = np.sum(SxyJointCounts, axis=1)
-        return SxyJointCounts, SMarginalCounts, SxJointCounts, SyJointCounts
-
-    def _Fill3DCountTableByUnique(dataSXY, cardSXY):
-        # Sometimes when the conditioning set contains many variables and each variable's cardinality is large
-        # e.g. consider an extreme case where
-        # S contains 7 variables and each's cardinality=20, then cardS = np.prod(cardSXY[:-2]) would be 1280000000
-        # i.e., there are 1280000000 different possible combinations of S,
-        #    so the SxyJointCounts array would be of size 1280000000 * cardX * cardY * np.int64,
-        #    i.e., ~3.73TB memory! (suppose cardX, cardX are also 20)
-        # However, samplesize is usually in 1k-100k scale, far less than cardS,
-        # i.e., not all (and actually only a very small portion of combinations of S appeared in data)
-        #    i.e., SMarginalCountsNonZero in _Fill3DCountTable_by_bincount is a very sparse array
-        # So when cardSXY is large, we first re-index S (skip the absent combinations) and then count XY table for each.
-        # See https://github.com/cmu-phil/causal-learn/pull/37.
-        cardX, cardY = cardSXY[-2:]
-        cardSs = cardSXY[:-2]
-
-        cardSsCumProd = np.ones_like(cardSs)
-        cardSsCumProd[:-1] = np.cumprod(cardSs[1:][::-1])[::-1]
-        SIndexed = np.dot(cardSsCumProd[None], dataSXY[:-2])[0]
-
-        uniqSIndices, inverseSIndices, SMarginalCounts = np.unique(SIndexed, return_counts=True, return_inverse=True)
-        cardS_reduced = len(uniqSIndices)
-        SxyIndexed = inverseSIndices * cardX * cardY + dataSXY[-2] * cardY + dataSXY[-1]
-        SxyJointCounts = np.bincount(SxyIndexed, minlength=cardS_reduced * cardX * cardY).reshape((cardS_reduced, cardX, cardY))
-
-        SxJointCounts = np.sum(SxyJointCounts, axis=2)
-        SyJointCounts = np.sum(SxyJointCounts, axis=1)
-        return SxyJointCounts, SMarginalCounts, SxJointCounts, SyJointCounts
-
-    def _Fill3DCountTable(dataSXY, cardSXY):
-        # about the threshold 1e5, see a rough performance example at:
-        # https://gist.github.com/MarkDana/e7d9663a26091585eb6882170108485e#file-count-unique-in-array-performance-md
-        if np.prod(cardSXY) < CONST_BINCOUNT_UNIQUE_THRESHOLD: return _Fill3DCountTableByBincount(dataSXY, cardSXY)
-        return _Fill3DCountTableByUnique(dataSXY, cardSXY)
-
-    def _CalculatePValue(cTables, eTables):
-        """
-        calculate the rareness (pValue) of an observation from a given distribution with certain sample size.
-
-        Let k, m, n be respectively the cardinality of S, x, y. if S=empty, k==1.
+class CIT(object):
+    def __init__(self, data, method='fisherz', **kwargs):
+        '''
         Parameters
         ----------
-        cTables: tensor, (k, m, n) the [c]ounted tables (reflect joint P_XY)
-        eTables: tensor, (k, m, n) the [e]xpected tables (reflect product of marginal P_X*P_Y)
-          if there are zero entires in eTables, zero must occur in whole rows or columns.
-          e.g. w.l.o.g., row eTables[w, i, :] == 0, iff np.sum(cTables[w], axis=1)[i] == 0, i.e. cTables[w, i, :] == 0,
-               i.e. in configuration of conditioning set == w, no X can be in value i.
+        data: numpy.ndarray of shape (n_samples, n_features)
+        method: str, in ["fisherz", "mv_fisherz", "mc_fisherz", "kci", "chisq", "gsq"]
+        kwargs: placeholder for future arguments, or for KCI specific arguments now
+        '''
+        self.data = data
+        self.data_hash = hash(str(data))
+        self.sample_size, self.num_features = data.shape
+        self.method = method
+        self.pvalue_cache = {}
 
-        Returns: pValue (float in range (0, 1)), the larger pValue is (>alpha), the more independent.
-        -------
+        if method == 'kci':
+            # parse kwargs contained in the KCI method
+            kci_kwargs = {k: v for k, v in kwargs.items() if k in
+                          ['kernelX', 'kernelY', 'null_ss', 'approx', 'est_width', 'polyd', 'kwidthx', 'kwidthy']}
+            self.kci_ui = KCI_UInd(**kci_kwargs)
+            self.kci_ci = KCI_CInd(**kci_kwargs)
+        elif method in ['fisherz', 'mv_fisherz', 'mc_fisherz']:
+            self.correlation_matrix = np.corrcoef(data.T)
+        elif method in ['chisq', 'gsq']:
+            def _unique(column):
+                return np.unique(column, return_inverse=True)[1]
+            self.data = np.apply_along_axis(_unique, 0, self.data).astype(np.int64)
+            self.data_hash = hash(str(self.data))
+            self.cardinalities = np.max(self.data, axis=0) + 1
+        else:
+            raise NotImplementedError(f"CITest method {method} is not implemented.")
+
+        self.named_caller = {
+            'fisherz': self.fisherz,
+            'mv_fisherz': self.mv_fisherz,
+            'mc_fisherz': self.mc_fisherz,
+            'kci': self.kci,
+            'chisq': self.chisq,
+            'gsq': self.gsq
+        }
+
+    def kci(self, X, Y, condition_set):
+        if len(condition_set) == 0:
+            return self.kci_ui.compute_pvalue(self.data[:, [X]], self.data[:, [Y]])[0]
+        return self.kci_ci.compute_pvalue(self.data[:, [X]], self.data[:, [Y]], self.data[:, list(condition_set)])[0]
+
+    def fisherz(self, X, Y, condition_set):
         """
-        eTables_zero_inds = eTables == 0
-        eTables_zero_to_one = np.copy(eTables)
-        eTables_zero_to_one[eTables_zero_inds] = 1  # for legal division
+        Perform an independence test using Fisher-Z's test
 
-        if G_sq == False:
-            sum_of_chi_square = np.sum(((cTables - eTables) ** 2) / eTables_zero_to_one)
+        Parameters
+        ----------
+        data : data matrices
+        X, Y and condition_set : column indices of data
+
+        Returns
+        -------
+        p : the p-value of the test
+        """
+        var = list((X, Y) + condition_set)
+        sub_corr_matrix = self.correlation_matrix[np.ix_(var, var)]
+        inv = np.linalg.inv(sub_corr_matrix)
+        r = -inv[0, 1] / sqrt(inv[0, 0] * inv[1, 1])
+        Z = 0.5 * log((1 + r) / (1 - r))
+        X = sqrt(self.sample_size - len(condition_set) - 3) * abs(Z)
+        p = 2 * (1 - norm.cdf(abs(X)))
+        return p
+
+    def mv_fisherz(self, X, Y, condition_set):
+        """
+        Perform an independence test using Fisher-Z's test for data with missing values
+
+        Parameters
+        ----------
+        mvdata : data with missing values
+        X, Y and condition_set : column indices of data
+
+        Returns
+        -------
+        p : the p-value of the test
+        """
+        def _get_index_no_mv_rows(mvdata):
+            nrow, ncol = np.shape(mvdata)
+            bindxRows = np.ones((nrow,), dtype=bool)
+            indxRows = np.array(list(range(nrow)))
+            for i in range(ncol):
+                bindxRows = np.logical_and(bindxRows, ~np.isnan(mvdata[:, i]))
+            indxRows = indxRows[bindxRows]
+            return indxRows
+        var = list((X, Y) + condition_set)
+        test_wise_deletion_XYcond_rows_index = _get_index_no_mv_rows(self.data[:, var])
+        assert len(test_wise_deletion_XYcond_rows_index) != 0, \
+            "A test-wise deletion fisher-z test appears no overlapping data of involved variables. Please check the input data."
+        test_wise_deleted_cit = CIT(self.data[test_wise_deletion_XYcond_rows_index], "fisherz")
+        assert not np.isnan(self.data[test_wise_deletion_XYcond_rows_index][:, var]).any()
+        return test_wise_deleted_cit(X, Y, condition_set)
+        # TODO: above is to be consistent with the original code; though below is more accurate (np.corrcoef issues)
+        # test_wise_deleted_data_var = self.data[test_wise_deletion_XYcond_rows_index][:, var]
+        # sub_corr_matrix = np.corrcoef(test_wise_deleted_data_var.T)
+        # inv = np.linalg.inv(sub_corr_matrix)
+        # r = -inv[0, 1] / sqrt(inv[0, 0] * inv[1, 1])
+        # Z = 0.5 * log((1 + r) / (1 - r))
+        # X = sqrt(self.sample_size - len(condition_set) - 3) * abs(Z)
+        # p = 2 * (1 - norm.cdf(abs(X)))
+        # return p
+
+    def mc_fisherz(self, X, Y, condition_set, skel, prt_m):
+        """Perform an independent test using Fisher-Z's test with test-wise deletion and missingness correction
+        If it is not the case which requires a correction, then call function mvfisherZ(...)
+        :param prt_m: dictionary, with elements:
+            - m: missingness indicators which are not MCAR
+            - prt: parents of the missingness indicators
+        """
+        ## Check whether whether there is at least one common child of X and Y
+        if not Helper.cond_perm_c(X, Y, condition_set, prt_m, skel):
+            return self.mv_fisherz(X, Y, condition_set)
+
+        ## *********** Step 1 ***********
+        # Learning generaive model for {X, Y, S} to impute X, Y, and S
+
+        ## Get parents the {xyS} missingness indicators with parents: prt_m
+        # W is the variable which can be used for missingness correction
+        W_indx_ = Helper.get_prt_mvars(var=list((X, Y) + condition_set), prt_m=prt_m)
+
+        if len(W_indx_) == 0:  # When there is no variable can be used for correction
+            return self.mv_fisherz(X, Y, condition_set)
+
+        ## Get the parents of W missingness indicators
+        W_indx = Helper.get_prt_mw(W_indx_, prt_m)
+
+        ## Prepare the W for regression
+        # Since the XYS will be regressed on W,
+        # W will not contain any of XYS
+        var = list((X, Y) + condition_set)
+        W_indx = list(set(W_indx) - set(var))
+
+        if len(W_indx) == 0:  # When there is no variable can be used for correction
+            return self.mv_fisherz(X, Y, condition_set)
+
+        ## Learn regression models with test-wise deleted data
+        involve_vars = var + W_indx
+        tdel_data = Helper.test_wise_deletion(self.data[:, involve_vars])
+        effective_sz = len(tdel_data[:, 0])
+        regMs, rss = Helper.learn_regression_model(tdel_data, num_model=len(var))
+
+        ## *********** Step 2 ***********
+        # Get the data of the predictors, Ws
+        # The sample size of Ws is the same as the effective sample size
+        Ws = Helper.get_predictor_ws(self.data[:, involve_vars], num_test_var=len(var), effective_sz=effective_sz)
+
+        ## *********** Step 3 ***********
+        # Generate the virtual data follows the full data distribution P(X, Y, S)
+        # The sample size of data_vir is the same as the effective sample size
+        data_vir = Helper.gen_vir_data(regMs, rss, Ws, len(var), effective_sz)
+
+        if len(var) > 2:
+            cond_set_bgn_0 = np.arange(2, len(var))
         else:
-            div = np.divide(cTables, eTables_zero_to_one)
-            div[div == 0] = 1  # It guarantees that taking natural log in the next step won't cause any error
-            sum_of_chi_square = 2 * np.sum(cTables * np.log(div))
+            cond_set_bgn_0 = []
 
-        # array in shape (k,), zero_counts_rows[w]=c (0<=c<m) means layer w has c all-zero rows
-        zero_counts_rows = eTables_zero_inds.all(axis=2).sum(axis=1)
-        zero_counts_cols = eTables_zero_inds.all(axis=1).sum(axis=1)
-        sum_of_df = np.sum((cTables.shape[1] - 1 - zero_counts_rows) * (cTables.shape[2] - 1 - zero_counts_cols))
-        return 1 if sum_of_df == 0 else chi2.sf(sum_of_chi_square, sum_of_df)
+        virtual_cit = CIT(data_vir, method='fisherz')
+        return virtual_cit.mv_fisherz(0, 1, tuple(cond_set_bgn_0))
 
-    if len(cardSXY) == 2:  # S is empty
-        xyJointCounts, xMarginalCounts, yMarginalCounts = _Fill2DCountTable(dataSXY, cardSXY)
-        xyExpectedCounts = np.outer(xMarginalCounts, yMarginalCounts) / dataSXY.shape[1]  # divide by sample size
-        return _CalculatePValue(xyJointCounts[None], xyExpectedCounts[None])
+    def chisq(self, X, Y, condition_set):
+        indexs = list(condition_set) + [X, Y]
+        return self._chisq_or_gsq_test(self.data[:, indexs].T, self.cardinalities[indexs])
 
-    # else, S is not empty: conditioning
-    SxyJointCounts, SMarginalCounts, SxJointCounts, SyJointCounts = _Fill3DCountTable(dataSXY, cardSXY)
-    SxyExpectedCounts = SxJointCounts[:, :, None] * SyJointCounts[:, None, :] / SMarginalCounts[:, None, None]
-    return _CalculatePValue(SxyJointCounts, SxyExpectedCounts)
+    def gsq(self, X, Y, condition_set):
+        indexs = list(condition_set) + [X, Y]
+        return self._chisq_or_gsq_test(self.data[:, indexs].T, self.cardinalities[indexs], G_sq=True)
 
+    def _chisq_or_gsq_test(self, dataSXY, cardSXY, G_sq=False):
+        """by Haoyue@12/18/2021
+        Parameters
+        ----------
+        dataSXY: numpy.ndarray, in shape (|S|+2, n), where |S| is size of conditioning set (can be 0), n is sample size
+                 dataSXY.dtype = np.int64, and each row has values [0, 1, 2, ..., card_of_this_row-1]
+        cardSXY: cardinalities of each row (each variable)
+        G_sq: True if use G-sq, otherwise (False by default), use Chi_sq
+        """
 
-######## below we save the original test (which is slower but easier-to-read) ###########
-######## logic of new test is exactly the same as old, so returns exactly same result ###
-def chisq_notoptimized(data, X, Y, conditioning_set):
-    return chisq_or_gsq_test_notoptimized(data=data, X=X, Y=Y, conditioning_set=conditioning_set)
+        def _Fill2DCountTable(dataXY, cardXY):
+            """
+            e.g. dataXY: the observed dataset contains 5 samples, on variable x and y they're
+                x: 0 1 2 3 0
+                y: 1 0 1 2 1
+            cardXY: [4, 3]
+            fill in the counts by index, we have the joint count table in 4 * 3:
+                xy| 0 1 2
+                --|-------
+                0 | 0 2 0
+                1 | 1 0 0
+                2 | 0 1 0
+                3 | 0 0 1
+            note: if sample size is large enough, in theory:
+                    min(dataXY[i]) == 0 && max(dataXY[i]) == cardXY[i] - 1
+                however some values may be missed.
+                also in joint count, not every value in [0, cardX * cardY - 1] occurs.
+                that's why we pass cardinalities in, and use `minlength=...` in bincount
+            """
+            cardX, cardY = cardXY
+            xyIndexed = dataXY[0] * cardY + dataXY[1]
+            xyJointCounts = np.bincount(xyIndexed, minlength=cardX * cardY).reshape(cardXY)
+            xMarginalCounts = np.sum(xyJointCounts, axis=1)
+            yMarginalCounts = np.sum(xyJointCounts, axis=0)
+            return xyJointCounts, xMarginalCounts, yMarginalCounts
 
+        def _Fill3DCountTableByBincount(dataSXY, cardSXY):
+            cardX, cardY = cardSXY[-2:]
+            cardS = np.prod(cardSXY[:-2])
+            cardCumProd = np.ones_like(cardSXY)
+            cardCumProd[:-1] = np.cumprod(cardSXY[1:][::-1])[::-1]
+            SxyIndexed = np.dot(cardCumProd[None], dataSXY)[0]
 
-def gsq_notoptimized(data, X, Y, conditioning_set):
-    return chisq_or_gsq_test_notoptimized(data=data, X=X, Y=Y, conditioning_set=conditioning_set, G_sq=True)
+            SxyJointCounts = np.bincount(SxyIndexed, minlength=cardS * cardX * cardY).reshape((cardS, cardX, cardY))
+            SMarginalCounts = np.sum(SxyJointCounts, axis=(1, 2))
+            SMarginalCountsNonZero = SMarginalCounts != 0
+            SMarginalCounts = SMarginalCounts[SMarginalCountsNonZero]
+            SxyJointCounts = SxyJointCounts[SMarginalCountsNonZero]
 
+            SxJointCounts = np.sum(SxyJointCounts, axis=2)
+            SyJointCounts = np.sum(SxyJointCounts, axis=1)
+            return SxyJointCounts, SMarginalCounts, SxJointCounts, SyJointCounts
 
-def chisq_or_gsq_test_notoptimized(data, X, Y, conditioning_set, G_sq=False):
-    """
-    Perform an independence test using chi-square test or G-square test
+        def _Fill3DCountTableByUnique(dataSXY, cardSXY):
+            # Sometimes when the conditioning set contains many variables and each variable's cardinality is large
+            # e.g. consider an extreme case where
+            # S contains 7 variables and each's cardinality=20, then cardS = np.prod(cardSXY[:-2]) would be 1280000000
+            # i.e., there are 1280000000 different possible combinations of S,
+            #    so the SxyJointCounts array would be of size 1280000000 * cardX * cardY * np.int64,
+            #    i.e., ~3.73TB memory! (suppose cardX, cardX are also 20)
+            # However, samplesize is usually in 1k-100k scale, far less than cardS,
+            # i.e., not all (and actually only a very small portion of combinations of S appeared in data)
+            #    i.e., SMarginalCountsNonZero in _Fill3DCountTable_by_bincount is a very sparse array
+            # So when cardSXY is large, we first re-index S (skip the absent combinations) and then count XY table for each.
+            # See https://github.com/cmu-phil/causal-learn/pull/37.
+            cardX, cardY = cardSXY[-2:]
+            cardSs = cardSXY[:-2]
 
-    Parameters
-    ----------
-    data : data matrices
-    X, Y and condition_set : column indices of data
-    G_sq : True means using G-square test;
-           False means using chi-square test
+            cardSsCumProd = np.ones_like(cardSs)
+            cardSsCumProd[:-1] = np.cumprod(cardSs[1:][::-1])[::-1]
+            SIndexed = np.dot(cardSsCumProd[None], dataSXY[:-2])[0]
 
-    Returns
-    -------
-    p : the p-value of the test
-    """
+            uniqSIndices, inverseSIndices, SMarginalCounts = np.unique(SIndexed, return_counts=True,
+                                                                       return_inverse=True)
+            cardS_reduced = len(uniqSIndices)
+            SxyIndexed = inverseSIndices * cardX * cardY + dataSXY[-2] * cardY + dataSXY[-1]
+            SxyJointCounts = np.bincount(SxyIndexed, minlength=cardS_reduced * cardX * cardY).reshape(
+                (cardS_reduced, cardX, cardY))
 
-    # Step 1: Subset the data
-    categories_list = [np.unique(data[:, i]) for i in
-                       list(conditioning_set)]  # Obtain the categories of each variable in conditioning_set
-    value_config_list = cartesian_product(
-        categories_list)  # Obtain all the possible value configurations of the conditioning_set (e.g., [[]] if categories_list == [])
+            SxJointCounts = np.sum(SxyJointCounts, axis=2)
+            SyJointCounts = np.sum(SxyJointCounts, axis=1)
+            return SxyJointCounts, SMarginalCounts, SxJointCounts, SyJointCounts
 
-    max_categories = int(
-        np.max(data)) + 1  # Used to fix the size of the contingency table (before applying Fienberg's method)
+        def _Fill3DCountTable(dataSXY, cardSXY):
+            # about the threshold 1e5, see a rough performance example at:
+            # https://gist.github.com/MarkDana/e7d9663a26091585eb6882170108485e#file-count-unique-in-array-performance-md
+            if np.prod(cardSXY) < CONST_BINCOUNT_UNIQUE_THRESHOLD: return _Fill3DCountTableByBincount(dataSXY, cardSXY)
+            return _Fill3DCountTableByUnique(dataSXY, cardSXY)
 
-    sum_of_chi_square = 0  # initialize a zero chi_square statistic
-    sum_of_df = 0  # initialize a zero degree of freedom
+        def _CalculatePValue(cTables, eTables):
+            """
+            calculate the rareness (pValue) of an observation from a given distribution with certain sample size.
 
-    def recursive_and(L):
-        "A helper function for subsetting the data using the conditions in L of the form [(variable, value),...]"
-        if len(L) == 0:
-            return data
+            Let k, m, n be respectively the cardinality of S, x, y. if S=empty, k==1.
+            Parameters
+            ----------
+            cTables: tensor, (k, m, n) the [c]ounted tables (reflect joint P_XY)
+            eTables: tensor, (k, m, n) the [e]xpected tables (reflect product of marginal P_X*P_Y)
+              if there are zero entires in eTables, zero must occur in whole rows or columns.
+              e.g. w.l.o.g., row eTables[w, i, :] == 0, iff np.sum(cTables[w], axis=1)[i] == 0, i.e. cTables[w, i, :] == 0,
+                   i.e. in configuration of conditioning set == w, no X can be in value i.
+
+            Returns: pValue (float in range (0, 1)), the larger pValue is (>alpha), the more independent.
+            -------
+            """
+            eTables_zero_inds = eTables == 0
+            eTables_zero_to_one = np.copy(eTables)
+            eTables_zero_to_one[eTables_zero_inds] = 1  # for legal division
+
+            if G_sq == False:
+                sum_of_chi_square = np.sum(((cTables - eTables) ** 2) / eTables_zero_to_one)
+            else:
+                div = np.divide(cTables, eTables_zero_to_one)
+                div[div == 0] = 1  # It guarantees that taking natural log in the next step won't cause any error
+                sum_of_chi_square = 2 * np.sum(cTables * np.log(div))
+
+            # array in shape (k,), zero_counts_rows[w]=c (0<=c<m) means layer w has c all-zero rows
+            zero_counts_rows = eTables_zero_inds.all(axis=2).sum(axis=1)
+            zero_counts_cols = eTables_zero_inds.all(axis=1).sum(axis=1)
+            sum_of_df = np.sum((cTables.shape[1] - 1 - zero_counts_rows) * (cTables.shape[2] - 1 - zero_counts_cols))
+            return 1 if sum_of_df == 0 else chi2.sf(sum_of_chi_square, sum_of_df)
+
+        if len(cardSXY) == 2:  # S is empty
+            xyJointCounts, xMarginalCounts, yMarginalCounts = _Fill2DCountTable(dataSXY, cardSXY)
+            xyExpectedCounts = np.outer(xMarginalCounts, yMarginalCounts) / dataSXY.shape[1]  # divide by sample size
+            return _CalculatePValue(xyJointCounts[None], xyExpectedCounts[None])
+
+        # else, S is not empty: conditioning
+        SxyJointCounts, SMarginalCounts, SxJointCounts, SyJointCounts = _Fill3DCountTable(dataSXY, cardSXY)
+        SxyExpectedCounts = SxJointCounts[:, :, None] * SyJointCounts[:, None, :] / SMarginalCounts[:, None, None]
+        return _CalculatePValue(SxyJointCounts, SxyExpectedCounts)
+
+    def __call__(self, X, Y, condition_set=None, *args):
+        if self.method != 'mc_fisherz':
+            assert len(args) == 0, "Arguments more than X, Y, and condition_set are provided."
         else:
-            condition = data[:, L[0][0]] == L[0][1]
-            i = 1
-            while i < len(L):
-                new_conjunct = data[:, L[i][0]] == L[i][1]
-                condition = new_conjunct & condition
-                i += 1
-            return data[condition]
+            assert len(args) == 2, "Arguments other than skel and prt_m are provided for mc_fisherz."
+        if condition_set is None: condition_set = tuple()
+        assert X not in condition_set and Y not in condition_set, "X, Y cannot be in condition_set."
+        i, j = (X, Y) if (X < Y) else (Y, X)
+        cache_key = (i, j, frozenset(condition_set))
 
-    for value_config in range(len(value_config_list)):
-        L = list(zip(conditioning_set, value_config_list[value_config]))
-        sub_data = recursive_and(L)[:, [X,
-                                        Y]]  # obtain the subset dataset (containing only the X, Y columns) with only rows specifed in value_config
-
-        ############# Haoyue@12/18/2021  DEBUG: this line is a must:  #####################
-        ########### not all value_config in cartesian product occurs in data ##############
-        # e.g. S=(S0,S1), where S0 has categories {0,1}, S1 has {2,3}. But in combination,#
-        ##### (S0,S1) only shows up with value pair (0,2), (0,3), (1,2) -> no (1,3). ######
-        ########### otherwise #degree_of_freedom will add a spurious 1: (0-1)*(0-1) #######
-        if len(sub_data) == 0: continue  #################################################
-
-        ###################################################################################
-
-        # Step 2: Generate contingency table (applying Fienberg's method)
-        def make_ctable(D, cat_size):
-            x = np.array(D[:, 0], dtype=np.dtype(int))
-            y = np.array(D[:, 1], dtype=np.dtype(int))
-            bin_count = np.bincount(cat_size * x + y)  # Perform linear transformation to obtain frequencies
-            diff = (cat_size ** 2) - len(bin_count)
-            if diff > 0:  # The number of cells generated by bin_count can possibly be less than cat_size**2
-                bin_count = np.concatenate(
-                    (bin_count, np.zeros(diff)))  # In that case, we concatenate some zeros to fit cat_size**2
-            ctable = bin_count.reshape(cat_size, cat_size)
-            ctable = ctable[~np.all(ctable == 0, axis=1)]  # Remove rows consisted entirely of zeros
-            ctable = ctable[:, ~np.all(ctable == 0, axis=0)]  # Remove columns consisted entirely of zeros
-
-            return ctable
-
-        ctable = make_ctable(sub_data, max_categories)
-
-        # Step 3: Calculate chi-square statistic and degree of freedom from the contingency table
-        row_sum = np.sum(ctable, axis=1)
-        col_sum = np.sum(ctable, axis=0)
-        expected = np.outer(row_sum, col_sum) / sub_data.shape[0]
-        if G_sq == False:
-            chi_sq_stat = np.sum(((ctable - expected) ** 2) / expected)
-        else:
-            div = np.divide(ctable, expected)
-            div[div == 0] = 1  # It guarantees that taking natural log in the next step won't cause any error
-            chi_sq_stat = 2 * np.sum(ctable * np.log(div))
-        df = (ctable.shape[0] - 1) * (ctable.shape[1] - 1)
-
-        sum_of_chi_square += chi_sq_stat
-        sum_of_df += df
-
-    # Step 4: Compute p-value from chi-square CDF
-    if sum_of_df == 0:
-        return 1
-    else:
-        return chi2.sf(sum_of_chi_square, sum_of_df)
+        if self.method != 'mc_fisherz' and cache_key in self.pvalue_cache: return self.pvalue_cache[cache_key]
+        pValue = self.named_caller[self.method](X, Y, condition_set) if self.method != 'mc_fisherz' else \
+                 self.mc_fisherz(X, Y, condition_set, *args)
+        self.pvalue_cache[cache_key] = pValue
+        return pValue
 
 
-def cartesian_product(lists):
-    "Return the Cartesian product of lists (List of lists)"
-    result = [[]]
-    for pool in lists:
-        result = [x + [y] for x in result for y in pool]
-    return result
 
 
-def get_index_no_mv_rows(mvdata):
-    nrow, ncol = np.shape(mvdata)
-    bindxRows = np.ones((nrow,), dtype=bool)
-    indxRows = np.array(list(range(nrow)))
-    for i in range(ncol):
-        bindxRows = np.logical_and(bindxRows, ~np.isnan(mvdata[:, i]))
-    indxRows = indxRows[bindxRows]
-    return indxRows
+
+
+#
+#
+# ######## below we save the original test (which is slower but easier-to-read) ###########
+# ######## logic of new test is exactly the same as old, so returns exactly same result ###
+# def chisq_notoptimized(data, X, Y, conditioning_set):
+#     return chisq_or_gsq_test_notoptimized(data=data, X=X, Y=Y, conditioning_set=conditioning_set)
+#
+#
+# def gsq_notoptimized(data, X, Y, conditioning_set):
+#     return chisq_or_gsq_test_notoptimized(data=data, X=X, Y=Y, conditioning_set=conditioning_set, G_sq=True)
+#
+#
+# def chisq_or_gsq_test_notoptimized(data, X, Y, conditioning_set, G_sq=False):
+#     """
+#     Perform an independence test using chi-square test or G-square test
+#
+#     Parameters
+#     ----------
+#     data : data matrices
+#     X, Y and condition_set : column indices of data
+#     G_sq : True means using G-square test;
+#            False means using chi-square test
+#
+#     Returns
+#     -------
+#     p : the p-value of the test
+#     """
+#
+#     # Step 1: Subset the data
+#     categories_list = [np.unique(data[:, i]) for i in
+#                        list(conditioning_set)]  # Obtain the categories of each variable in conditioning_set
+#     value_config_list = cartesian_product(
+#         categories_list)  # Obtain all the possible value configurations of the conditioning_set (e.g., [[]] if categories_list == [])
+#
+#     max_categories = int(
+#         np.max(data)) + 1  # Used to fix the size of the contingency table (before applying Fienberg's method)
+#
+#     sum_of_chi_square = 0  # initialize a zero chi_square statistic
+#     sum_of_df = 0  # initialize a zero degree of freedom
+#
+#     def recursive_and(L):
+#         "A helper function for subsetting the data using the conditions in L of the form [(variable, value),...]"
+#         if len(L) == 0:
+#             return data
+#         else:
+#             condition = data[:, L[0][0]] == L[0][1]
+#             i = 1
+#             while i < len(L):
+#                 new_conjunct = data[:, L[i][0]] == L[i][1]
+#                 condition = new_conjunct & condition
+#                 i += 1
+#             return data[condition]
+#
+#     for value_config in range(len(value_config_list)):
+#         L = list(zip(conditioning_set, value_config_list[value_config]))
+#         sub_data = recursive_and(L)[:, [X,
+#                                         Y]]  # obtain the subset dataset (containing only the X, Y columns) with only rows specifed in value_config
+#
+#         ############# Haoyue@12/18/2021  DEBUG: this line is a must:  #####################
+#         ########### not all value_config in cartesian product occurs in data ##############
+#         # e.g. S=(S0,S1), where S0 has categories {0,1}, S1 has {2,3}. But in combination,#
+#         ##### (S0,S1) only shows up with value pair (0,2), (0,3), (1,2) -> no (1,3). ######
+#         ########### otherwise #degree_of_freedom will add a spurious 1: (0-1)*(0-1) #######
+#         if len(sub_data) == 0: continue  #################################################
+#
+#         ###################################################################################
+#
+#         # Step 2: Generate contingency table (applying Fienberg's method)
+#         def make_ctable(D, cat_size):
+#             x = np.array(D[:, 0], dtype=np.dtype(int))
+#             y = np.array(D[:, 1], dtype=np.dtype(int))
+#             bin_count = np.bincount(cat_size * x + y)  # Perform linear transformation to obtain frequencies
+#             diff = (cat_size ** 2) - len(bin_count)
+#             if diff > 0:  # The number of cells generated by bin_count can possibly be less than cat_size**2
+#                 bin_count = np.concatenate(
+#                     (bin_count, np.zeros(diff)))  # In that case, we concatenate some zeros to fit cat_size**2
+#             ctable = bin_count.reshape(cat_size, cat_size)
+#             ctable = ctable[~np.all(ctable == 0, axis=1)]  # Remove rows consisted entirely of zeros
+#             ctable = ctable[:, ~np.all(ctable == 0, axis=0)]  # Remove columns consisted entirely of zeros
+#
+#             return ctable
+#
+#         ctable = make_ctable(sub_data, max_categories)
+#
+#         # Step 3: Calculate chi-square statistic and degree of freedom from the contingency table
+#         row_sum = np.sum(ctable, axis=1)
+#         col_sum = np.sum(ctable, axis=0)
+#         expected = np.outer(row_sum, col_sum) / sub_data.shape[0]
+#         if G_sq == False:
+#             chi_sq_stat = np.sum(((ctable - expected) ** 2) / expected)
+#         else:
+#             div = np.divide(ctable, expected)
+#             div[div == 0] = 1  # It guarantees that taking natural log in the next step won't cause any error
+#             chi_sq_stat = 2 * np.sum(ctable * np.log(div))
+#         df = (ctable.shape[0] - 1) * (ctable.shape[1] - 1)
+#
+#         sum_of_chi_square += chi_sq_stat
+#         sum_of_df += df
+#
+#     # Step 4: Compute p-value from chi-square CDF
+#     if sum_of_df == 0:
+#         return 1
+#     else:
+#         return chi2.sf(sum_of_chi_square, sum_of_df)
+#
+#
+# def cartesian_product(lists):
+#     "Return the Cartesian product of lists (List of lists)"
+#     result = [[]]
+#     for pool in lists:
+#         result = [x + [y] for x in result for y in pool]
+#     return result
+
+
+
+
+

--- a/tests/TestFCI.py
+++ b/tests/TestFCI.py
@@ -99,7 +99,7 @@ class TestFCI(unittest.TestCase):
             "andes"
         ]
 
-        bnlearn_path = './TestData/bnlearn_discrete_10000'
+        bnlearn_path = './TestData/bnlearn_discrete_10000/data'
         for bname in benchmark_names:
             data = np.loadtxt(os.path.join(bnlearn_path, f'{bname}.txt'), skiprows=1)
             G, edges = fci(data, chisq, 0.05, verbose=False)

--- a/tests/TestMVPC_mv_fisherz_test.py
+++ b/tests/TestMVPC_mv_fisherz_test.py
@@ -10,7 +10,7 @@ sys.path.append(path)
 
 import unittest
 import numpy as np
-from causallearn.utils.cit import fisherz, mv_fisherz
+from causallearn.utils.cit import CIT
 
 
 class TestCIT_mv_fisherz(unittest.TestCase):
@@ -34,11 +34,12 @@ class TestCIT_mv_fisherz(unittest.TestCase):
             # Z -->R_Y   
 
             mdata[Z > 0, 1] = np.nan
-
-            mv_pvalues_t1.append(mv_fisherz(mdata, 0, 1, ()))
-            pvalues_t1.append(fisherz(data, 0, 1, ()))
-            mv_pvalues_t2.append(mv_fisherz(mdata, 0, 1, (2,)))
-            pvalues_t2.append(fisherz(data, 0, 1, (2,)))
+            indep_test = CIT(data, method='fisherz')
+            mv_indep_test = CIT(mdata, method='mv_fisherz')
+            mv_pvalues_t1.append(mv_indep_test(0, 1, ()))
+            pvalues_t1.append(indep_test(0, 1, ()))
+            mv_pvalues_t2.append(mv_indep_test(0, 1, (2,)))
+            pvalues_t2.append(indep_test(0, 1, (2,)))
 
         print('mv_fisherz: X and Y are not independent, pvalue is mean {:.3f}'.format(np.mean(mv_pvalues_t1)) + ' std: {:.3f}'.format(np.std(mv_pvalues_t1)))
         print('fisherz: X and Y are not independent, pvalue is mean {:.3f}'.format(np.mean(pvalues_t1)) + ' std: {:.3f}'.format(np.std(pvalues_t1)))
@@ -68,10 +69,13 @@ class TestCIT_mv_fisherz(unittest.TestCase):
 
             mdata[Z > 0, 1] = np.nan
 
-            mv_pvalues_t1.append(mv_fisherz(mdata, 0, 1, ()))
-            pvalues_t1.append(fisherz(data, 0, 1, ()))
-            mv_pvalues_t2.append(mv_fisherz(mdata, 0, 1, (2,)))
-            pvalues_t2.append(fisherz(data, 0, 1, (2,)))
+            indep_test = CIT(data, method='fisherz')
+            mv_indep_test = CIT(mdata, method='mv_fisherz')
+
+            mv_pvalues_t1.append(mv_indep_test(0, 1, ()))
+            pvalues_t1.append(indep_test(0, 1, ()))
+            mv_pvalues_t2.append(mv_indep_test(0, 1, (2,)))
+            pvalues_t2.append(indep_test(0, 1, (2,)))
 
         print('mv_fisherz: X and Y are not independent, pvalue is mean {:.3f}'.format(np.mean(mv_pvalues_t1)) + ' std: {:.3f}'.format(np.std(mv_pvalues_t1)))
         print('fisherz: X and Y are not independent, pvalue is mean {:.3f}'.format(np.mean(pvalues_t1)) + ' std: {:.3f}'.format(np.std(pvalues_t1)))
@@ -101,10 +105,13 @@ class TestCIT_mv_fisherz(unittest.TestCase):
 
             mdata[Z > 0, 1] = np.nan
 
-            mv_pvalues_t1.append(mv_fisherz(mdata, 0, 1, ()))
-            pvalues_t1.append(fisherz(data, 0, 1, ()))
-            mv_pvalues_t2.append(mv_fisherz(mdata, 0, 1, (2,)))
-            pvalues_t2.append(fisherz(data, 0, 1, (2,)))
+            indep_test = CIT(data, method='fisherz')
+            mv_indep_test = CIT(mdata, method='mv_fisherz')
+
+            mv_pvalues_t1.append(mv_indep_test(0, 1, ()))
+            pvalues_t1.append(indep_test(0, 1, ()))
+            mv_pvalues_t2.append(mv_indep_test(0, 1, (2,)))
+            pvalues_t2.append(indep_test(0, 1, (2,)))
 
         print('mv_fisherz: X and Y are independent, pvalue is mean {:.3f}'.format(np.mean(mv_pvalues_t1)) + ' std: {:.3f}'.format(np.std(mv_pvalues_t1)))
         print('fisherz: X and Y are independent, pvalue is mean {:.3f}'.format(np.mean(pvalues_t1)) + ' std: {:.3f}'.format(np.std(pvalues_t1)))
@@ -133,10 +140,13 @@ class TestCIT_mv_fisherz(unittest.TestCase):
 
             mdata[Y > 0, 2] = np.nan
 
-            mv_pvalues_t1.append(mv_fisherz(mdata, 0, 1, ()))
-            pvalues_t1.append(fisherz(data, 0, 1, ()))
-            mv_pvalues_t2.append(mv_fisherz(mdata, 0, 1, (2,)))
-            pvalues_t2.append(fisherz(data, 0, 1, (2,)))
+            indep_test = CIT(data, method='fisherz')
+            mv_indep_test = CIT(mdata, method='mv_fisherz')
+
+            mv_pvalues_t1.append(mv_indep_test(0, 1, ()))
+            pvalues_t1.append(indep_test(0, 1, ()))
+            mv_pvalues_t2.append(mv_indep_test(0, 1, (2,)))
+            pvalues_t2.append(indep_test(0, 1, (2,)))
 
         print('mv_fisherz: X and Y are independent, pvalue is mean {:.3f}'.format(np.mean(mv_pvalues_t1)) + ' std: {:.3f}'.format(np.std(mv_pvalues_t1)))
         print('fisherz: X and Y are independent, pvalue is mean {:.3f}'.format(np.mean(pvalues_t1)) + ' std: {:.3f}'.format(np.std(pvalues_t1)))

--- a/tests/TestPC.py
+++ b/tests/TestPC.py
@@ -4,11 +4,14 @@ sys.path.append("")
 import unittest
 import hashlib
 import numpy as np
+np.random.seed(42)
 from causallearn.search.ConstraintBased.PC import pc
 from causallearn.utils.cit import chisq, fisherz, gsq, kci, mv_fisherz
 from causallearn.graph.SHD import SHD
 from causallearn.utils.DAG2CPDAG import dag2cpdag
 from causallearn.utils.TXT2GeneralGraph import txt2generalgraph
+
+
 
 ######################################### Test Notes ###########################################
 # All the benchmark results of loaded files (e.g. "./TestData/benchmark_returned_results/")    #


### PR DESCRIPTION
### Updated files:

+ `cit.py`: main change: integrate CITests functions to a class
+ `PC.py`, `FCI.py`, `CDNOD.py`, `Fas.py`, `SkeletonDiscovery.py`: adjust accordingly for the new CIT class.
+ `GraphClass.py`: remove unnecessary attributes (e.g., data, cache) in the `CausalGraph` class.
+ `TestPC.py`: there is randomness in `mvpc`, and thus we need two lines of test: w/ or wo/ randomness.
+ `TestFCI.py`, `TestMVPC_mv_fisherz_test.py`: minor issues (e.g., file directory).


### Why this update is needed:
+ **1. Speedup.** In current `pc` and `fisherz`, the correlation matrix over a same dataset `data` is re-computed at every call on `fisherz`, which wastes lots of time. Thanks @Yujia for raising this speedup!
+ However, if we simply add a `if indep_test == fisherz` line and pass the pre-computed `corr_mat` to `fisherz` at every possible usage, code will be super lengthy and ugly: `indep_test` is used everywhere in constraint-based methods, and parameters passing will be complicated.
+ An example of above: for speedup, we added CITest cache and cardinalities of gsq/chisq tests [before](https://github.com/cmu-phil/causal-learn/pull/9). However, to achieve this, these parameters are passed all across modules, e.g. [here](https://github.com/cmu-phil/causal-learn/blob/104b5dd3c9bf8991b22335ed65df2522b545e524/causallearn/search/ConstraintBased/FCI.py#L44), [here](https://github.com/cmu-phil/causal-learn/blob/104b5dd3c9bf8991b22335ed65df2522b545e524/causallearn/utils/PCUtils/SkeletonDiscovery.py#L62), and [here](https://github.com/cmu-phil/causal-learn/blob/104b5dd3c9bf8991b22335ed65df2522b545e524/causallearn/utils/Fas.py#L59).
+ **2. To make further changes on CITests easier**. Now all attributes of a specific CItests is stored in its CIT object, including `data`, `cache`, and: `corr_mat` for `fisherz`, `cardinalities` for `gsq/chisq`, user-specified parameters for `kci`, etc.


### How to use the CIT class
+ For users, any algorithms can be run end-to-end in a same way as before, e.g.,

```python
from causallearn.search.ConstraintBased.PC import pc
from causallearn.utils.cit import fisherz

cg = pc(data, 0.05, fisherz)
```
though they may notice that now `causallearn.utils.cit.fisherz` is a string `"fisherz"`, instead of the function before.

+ For developers, now we should write code as:

```python
from causallearn.utils.cit import CIT

fisherz_obj = CIT(data, "fisherz") # construct a CIT instance with data and method name
pValue = fisherz_obj(X, Y, S) # a simple call is ok. no need to consider cache/corr_mat etc. by yourself.
```

while before we write code as:

```python
from causallearn.utils.cit import fisherz

# some complex if..then.. considerations before calculation, e.g., corr_mat, cache.
pValue = fisherz(data, X, Y, S)
```

### Test plan:
To ensure the new CIT class is correct and does not change the logic of the original code (as of commit 94d1536):

```bash
python -m unittest TestPC    # should pass
python -m unittest TestFCI    # should pass
python -m unittest TestCDNOD    # should pass
python -m unittest TestMVPC    # should pass
python -m unittest TestMVPC_mv_fisherz_test.py    # should pass
python -m unittest TestMVPC_mv_fisherz.py    # should pass except for test_pc_with_mv_fisherz_MCAR_data_assertion, which cannot pass in the original code.
```

### Speedup gain:
E.g., for `TestPC.TestPC.test_pc_with_fisher_z`, it takes `24.812s` in a run of the original code. Now it takes `3.748s`.

### Todo:
+ `cit.py: L113`: `np.corr` numerical issues with `nan` values.
+ To affect as less code as possible, now we deleted unnecessary attributes e.g., `data`, `cache` in the `CausalGraph` class. While we still have `test` attributes (a `CIT` object), to adapt to `cg.ci_test` methods in the original codes. But, for simplicity, should `test` be part of a graph class, eventually?
