### PR TITLE
KCI mild speedup

### DIFF
--- a/causallearn/search/FCMBased/lingam/hsic.py
+++ b/causallearn/search/FCMBased/lingam/hsic.py
@@ -84,7 +84,7 @@ def get_gram_matrix(X, width):
     K_colsums = K.sum(axis=0)
     K_rowsums = K.sum(axis=1)
     K_allsum = K_rowsums.sum()
-    Kc = K - (K_colsums[None, :] + K_rowsums[:, None]) / n + np.ones((n, n)) * (K_allsum / n ** 2)
+    Kc = K - (K_colsums[None, :] + K_rowsums[:, None]) / n + (K_allsum / n ** 2)
     # equivalent to H @ K @ H, where H = np.eye(n) - 1 / n * np.ones((n, n)).
     return K, Kc
 

--- a/causallearn/utils/KCI/KCI.py
+++ b/causallearn/utils/KCI/KCI.py
@@ -224,7 +224,7 @@ class KCI_UInd(object):
         where n is usually big (sample size).
         """
         T = Kx.shape[0]
-        mean_appr = np.diag(Kx).sum() * np.diag(Ky).sum() / T # same as np.trace(Kx) * np.trace(Ky) / T. a bit faster
+        mean_appr = np.trace(Kx) * np.trace(Ky) / T
         var_appr = 2 * np.sum(Kx ** 2) * np.sum(Ky ** 2) / T / T # same as np.sum(Kx * Kx.T) ..., here Kx is symmetric
         k_appr = mean_appr ** 2 / var_appr
         theta_appr = var_appr / mean_appr

--- a/causallearn/utils/KCI/Kernel.py
+++ b/causallearn/utils/KCI/Kernel.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 
+import numpy as np
 from numpy import eye, shape, ndarray
 from numpy.linalg import pinv
 
@@ -25,10 +26,19 @@ class Kernel(object):
     def center_kernel_matrix(K: ndarray):
         """
         Centers the kernel matrix via a centering matrix H=I-1/n and returns HKH
+        [Updated @Haoyue 06/24/2022]
+        equivalent to:
+            H = eye(n) - 1.0 / n
+            return H.dot(K.dot(H))
+        since n is always big, we can save time on the dot product by plugging H into dot and expand as sum.
+        time complexity is reduced from O(n^3) (matrix dot) to O(n^2) (traverse each element).
+        Also, consider the fact that here K (both Kx and Ky) are symmetric matrices, so K_colsums == K_rowsums
         """
+        # assert np.all(K == K.T), 'K should be symmetric'
         n = shape(K)[0]
-        H = eye(n) - 1.0 / n
-        return H.dot(K.dot(H))
+        K_colsums = K.sum(axis=0)
+        K_allsum = K_colsums.sum()
+        return K - (K_colsums[None, :] + K_colsums[:, None]) / n + (K_allsum / n ** 2)
 
     def center_kernel_matrix_regression(K: ndarray, Kz: ndarray, epsilon: float):
         """
@@ -36,4 +46,4 @@ class Kernel(object):
         """
         n = shape(K)[0]
         Rz = epsilon * pinv(Kz + epsilon * eye(n))
-        return Rz.dot(K.dot(Rz))
+        return Rz.dot(K.dot(Rz)), Rz

--- a/causallearn/utils/cit.py
+++ b/causallearn/utils/cit.py
@@ -31,10 +31,13 @@ class CIT(object):
 
         if method == 'kci':
             # parse kwargs contained in the KCI method
-            kci_kwargs = {k: v for k, v in kwargs.items() if k in
-                          ['kernelX', 'kernelY', 'null_ss', 'approx', 'est_width', 'polyd', 'kwidthx', 'kwidthy']}
-            self.kci_ui = KCI_UInd(**kci_kwargs)
-            self.kci_ci = KCI_CInd(**kci_kwargs)
+            kci_ui_kwargs = {k: v for k, v in kwargs.items() if k in
+                             ['kernelX', 'kernelY', 'null_ss', 'approx', 'est_width', 'polyd', 'kwidthx', 'kwidthy']}
+            kci_ci_kwargs = {k: v for k, v in kwargs.items() if k in
+                             ['kernelX', 'kernelY', 'kernelZ', 'null_ss', 'approx', 'use_gp', 'est_width', 'polyd',
+                              'kwidthx', 'kwidthy', 'kwidthz']}
+            self.kci_ui = KCI_UInd(**kci_ui_kwargs)
+            self.kci_ci = KCI_CInd(**kci_ci_kwargs)
         elif method in ['fisherz', 'mv_fisherz', 'mc_fisherz']:
             self.correlation_matrix = np.corrcoef(data.T)
         elif method in ['chisq', 'gsq']:


### PR DESCRIPTION
### Updated functions:
+ `causallearn/utils/KCI/KCI.py`:
   - `KCI_UInd.get_kappa`: reduce O(n^3) to O(n^2) based on the equation `np.trace(K.dot(K)) == np.sum(K * K.T)`.
   - L429 `elif self.kernelY == 'Polynomial'`: fixed a naming bug in original code. Should be `kernelZ`.
   - `KCI_CInd.KCI_V_statistic`: L479, reduced one repeated calculation based on the fact that `Kzx` and `Kzy` are usually same.
 + `causallearn/utils/KCI/Kernel.py`:
   - `Kernel.center_kernel_matrix`: reduce O(n^3) to O(n^2) by plugging `H = eye(n) - 1.0 / n` into `H.dot(K.dot(H))` and preventing the matrix multiplication.
 + `causallearn/search/FCMBased/lingam/hsic.py`: similar trick as `Kernel.center_kernel_matrix`.
 + `causallearn/utils/cit.py`: some trivial issue about specifying KCI kwargs.

### Speedup gain:
+ `KCI_UInd` (unconditional test): huge speedup (order of magnitude).
+ `KCI_CInd` (conditional test): reduces around 30% of time.
+ Overall, since conditional tests is always the bottleneck in an algorithm, this speedup is mild.
+ And thus we'll need more efficient way to calculate inverse and eigens of big matrix.

### Test plan:
+ To ensure that this update is logically consistent with the original code (under any possible parameters):
```python
np.random.seed(42)
from causallearn_fa79007.utils.cit import CIT as CIT_new
from causallearn_97e03ff.utils.cit import CIT as CIT_old

data = np.random.uniform(-1, 1, (100, 4))
for kernelname in ['Gaussian', 'Polynomial', 'Linear']:
    for est_width in ['empirical', 'median', 'manual']:
        for kwidth in [0.05, 0.1, 0.2]:
            for use_gp in [True, False]:
                for approx in [True, False]:
                    for polyd in [1, 2]:
                        kci_new = CIT_new(data, 'kci', kernelX=kernelname, kernelY=kernelname, kernelZ=kernelname,
                                              est_width=est_width, use_gp=use_gp, approx=approx, polyd=polyd,
                                              kwidthx=kwidth, kwidthy=kwidth, kwidthz=kwidth)
                        kci_old = CIT_old(data, 'kci', kernelX=kernelname, kernelY=kernelname, kernelZ=kernelname,
                                              est_width=est_width, use_gp=use_gp, approx=approx, polyd=polyd,
                                              kwidthx=kwidth, kwidthy=kwidth, kwidthz=kwidth)

                        # since there is randomness in null_sample_spectral, we need to fix the same seed for old and new run
                        np.random.seed(42); new_pval = kci_new(0, 1)
                        np.random.seed(42); old_pval = kci_old(0, 1)
                        assert np.isclose(old_pval, new_pval), "KCI_UIND is inconsistent after update."

                        np.random.seed(42); new_pval = kci_new(0, 1, (2, 3))
                        np.random.seed(42); old_pval = kci_old(0, 1, (2, 3))
                        assert np.isclose(old_pval, new_pval), "KCI_CIND is inconsistent after update."
```

+ Test speedup for `KCI_UInd`:
```python
for samplesize in range(1000, 20001, 1000):
    data = np.random.uniform(-1, 1, (samplesize, 2))
    kci_new = CIT_new(data, 'kci')
    kci_old = CIT_old(data, 'kci')
    tic = time.time(); kci_new(0, 1); tac = time.time(); time_new = tac - tic
    tic = time.time(); kci_old(0, 1); tac = time.time(); time_old = tac - tic
    print(f'{samplesize}:   {time_new} {time_old}')
```

<details>
<summary>Click to expand result</summary>

1000:   0.021124839782714844 0.051096200942993164
2000:   0.09719705581665039 0.2551460266113281
3000:   0.2547168731689453 0.7614071369171143
4000:   0.41847896575927734 1.7734618186950684
5000:   0.6685688495635986 3.47568416595459
6000:   0.9402382373809814 5.513365030288696
7000:   1.2306361198425293 9.101417064666748
8000:   1.7108919620513916 13.641188144683838
9000:   2.544398069381714 19.632148027420044
10000:   2.4818150997161865 25.683223009109497
11000:   2.8643081188201904 34.334508180618286
12000:   3.705733060836792 42.83501696586609
13000:   4.3541929721832275 56.730401039123535
14000:   4.609248161315918 68.94092202186584
15000:   5.336583852767944 83.44993829727173
16000:   6.201767921447754 103.21840572357178
17000:   7.315479040145874 128.12122511863708
18000:   8.262160062789917 153.92690014839172
19000:   8.924943208694458 182.9679470062256
20000:   9.806303977966309 210.9531922340393
</details>

![time_uind](https://user-images.githubusercontent.com/42901288/177089397-b2177630-95fd-489a-9780-4a18276d66d8.png)


+ Test speedup for `KCI_CInd`:
```python
for samplesize in range(500, 10000, 250):
    data = np.random.uniform(-1, 1, (samplesize, 4))
    kci_new = CIT_new(data, 'kci')
    kci_old = CIT_old(data, 'kci')
    tic = time.time(); kci_new(0, 1, (2, 3)); tac = time.time(); time_new = tac - tic
    tic = time.time(); kci_old(0, 1, (2, 3)); tac = time.time(); time_old = tac - tic
    print(f'{samplesize}:   {time_new} {time_old}')
```

<details>
<summary>Click to expand result</summary>

500:   0.07363319396972656 0.10682296752929688
750:   0.23387503623962402 0.3343160152435303
1000:   0.4689028263092041 0.6680917739868164
1250:   1.0056912899017334 1.4335689544677734
1500:   1.8545763492584229 2.555225133895874
1750:   2.874561071395874 4.148720979690552
2000:   4.18735408782959 5.866267681121826
2250:   6.662433862686157 9.67330002784729
2500:   9.315114974975586 12.643889904022217
2750:   12.94197392463684 17.26453423500061
3000:   15.682774782180786 22.286062002182007
3250:   19.692520141601562 27.745235919952393
3500:   24.944950103759766 35.524142265319824
3750:   31.416036128997803 44.23967480659485
4000:   37.706125020980835 52.7396559715271
4250:   47.966763973236084 65.09382581710815
4500:   54.48931813240051 75.27616381645203
4750:   62.57163095474243 87.28439497947693
5000:   73.18962788581848 103.77545189857483
5250:   83.41915202140808 117.27962899208069
5500:   94.05676174163818 132.2629098892212
5750:   108.3281478881836 151.59633588790894
6000:   126.17060780525208 180.97449898719788
6250:   136.30685591697693 191.5569679737091
6500:   151.8123619556427 212.14035725593567
6750:   170.19479298591614 239.7194480895996
7000:   199.10978388786316 270.4898717403412
7250:   206.63027906417847 290.0352849960327
7500:   226.2251410484314 315.22972893714905
7750:   248.7306571006775 345.4090187549591
8000:   290.0406291484833 413.12121295928955
8250:   313.7044348716736 450.7824430465698
8500:   332.1730182170868 466.674519777298
8750:   352.3237581253052 486.6480839252472
9000:   374.6881170272827 519.5066709518433
9250:   412.67669320106506 571.1528761386871
9500:   436.2383370399475 612.9915819168091
9750:   474.7570939064026 669.191967010498
</details>

![time_cind](https://user-images.githubusercontent.com/42901288/177089581-72dd0c84-a24c-4122-8d22-1dd02fc005a5.png)



