### PR TITLE
Fix NaN problem while normailze the data

### DIFF
--- a/causallearn/utils/KCI/KCI.py
+++ b/causallearn/utils/KCI/KCI.py
@@ -145,8 +145,16 @@ class KCI_UInd(object):
         else:
             raise Exception('Undefined kernel function')
 
-        data_x = stats.zscore(data_x, axis=0)
-        data_y = stats.zscore(data_y, axis=0)
+        if (np.var(data_x)==0):
+            data_x-=np.average(data_x)
+        else:
+            data_x = stats.zscore(data_x, axis=0)
+
+        if (np.var(data_y)==0):
+            data_y-=np.average(data_y)
+        else:
+            data_y = stats.zscore(data_y, axis=0)
+        
         Kx = kernelX.kernel(data_x)
         Ky = kernelY.kernel(data_y)
         return Kx, Ky
@@ -322,9 +330,20 @@ class KCI_CInd(object):
         kzy: centering kernel matrix for data_y (nxn)
         """
         # normalize the data
-        data_x = stats.zscore(data_x, axis=0)
-        data_y = stats.zscore(data_y, axis=0)
-        data_z = stats.zscore(data_z, axis=0)
+        if (np.var(data_x)==0):
+            data_x-=np.average(data_x)
+        else:
+            data_x = stats.zscore(data_x, axis=0)
+
+        if (np.var(data_y)==0):
+            data_y-=np.average(data_y)
+        else:
+            data_y = stats.zscore(data_y, axis=0)
+
+        if (np.var(data_z)==0):
+            data_z-=np.average(data_z)
+        else:
+            data_z = stats.zscore(data_z, axis=0)
 
         # concatenate x and z
         data_x = np.concatenate((data_x, 0.5 * data_z), axis=1)


### PR DESCRIPTION
Here is a problem when `data_x/data_y/data_z` have the same value, e.g. $Z = [1,1,1,\cdots,1]$, the result of `stats.zscore(data)` would be `NaN`, which caused the error in the subsequent `eigh` section.