### PR TITLE
Added some unit tests for GIN

### DIFF
--- a/causallearn/search/HiddenCausal/GIN/GIN.py
+++ b/causallearn/search/HiddenCausal/GIN/GIN.py
@@ -27,8 +27,8 @@ def GIN(data, indep_test_method='kci', alpha=0.05):
     ----------
     data : numpy ndarray
            data set
-    indep_test : str, default='kci'
-        the function of the independence test being used
+    indep_test_method : str, default='kci'
+        the name of the independence test being used
     alpha : float, default=0.05
         desired significance level of independence tests (p_value) in (0,1)
     Returns
@@ -47,7 +47,7 @@ def GIN(data, indep_test_method='kci', alpha=0.05):
     if indep_test_method not in ['kci', 'hsic']:
         raise NotImplementedError((f"Independent test method {indep_test_method} is not implemented."))
 
-    def indep_test(x, y, method=indep_test_method):
+    def indep_test(x, y, method):
         if method == 'kci':
             return kci.compute_pvalue(x, y)[0]
         elif method == 'hsic':
@@ -65,7 +65,7 @@ def GIN(data, indep_test_method='kci', alpha=0.05):
             e = cal_e_with_gin(data, cov, list(cluster), list(remain_var_set))
             pvals = []
             for z in range(len(remain_var_set)):
-                pvals.append(indep_test(data[:, [z]], e[:, None]))
+                pvals.append(indep_test(data[:, [z]], e[:, None], method=indep_test_method))
             fisher_pval = fisher_test(pvals)
             if fisher_pval >= alpha:
                 tmp_clusters_list.append(cluster)
@@ -96,7 +96,7 @@ def GIN(data, indep_test_method='kci', alpha=0.05):
                 e = cal_e_with_gin(data, cov, X + cluster_i1 + cluster_j1, Z + cluster_i2)
                 pvals = []
                 for z in range(len(Z + cluster_i2)):
-                    pvals.append(indep_test(data[:, [z]], e[:, None]))
+                    pvals.append(indep_test(data[:, [z]], e[:, None], method=indep_test_method))
                 fisher_pval = fisher_test(pvals)
                 if fisher_pval < alpha:
                     is_root = False

--- a/causallearn/search/HiddenCausal/GIN/GIN.py
+++ b/causallearn/search/HiddenCausal/GIN/GIN.py
@@ -35,16 +35,25 @@ def GIN(data, indep_test_method='kci', alpha=0.05):
     -------
     G : general graph
         causal graph
-    K : list
+    causal_order : list
         causal order
     '''
     n = data.shape[1]
     cov = np.cov(data.T)
 
     if indep_test_method == 'kci':
-        indep_test = KCI_UInd()
-    else:
+        kci = KCI_UInd()
+
+    if indep_test_method not in ['kci', 'hsic']:
         raise NotImplementedError((f"Independent test method {indep_test_method} is not implemented."))
+
+    def indep_test(x, y, method=indep_test_method):
+        if method == 'kci':
+            return kci.compute_pvalue(x, y)[0]
+        elif method == 'hsic':
+            return hsic_test_gamma(x, y)[1]
+        else:
+            raise NotImplementedError((f"Independent test method {indep_test_method} is not implemented."))
 
     var_set = set(range(n))
     cluster_size = 2
@@ -56,7 +65,7 @@ def GIN(data, indep_test_method='kci', alpha=0.05):
             e = cal_e_with_gin(data, cov, list(cluster), list(remain_var_set))
             pvals = []
             for z in range(len(remain_var_set)):
-                pvals.append(indep_test.compute_pvalue(data[:, [z]], e[:, None])[0])
+                pvals.append(indep_test(data[:, [z]], e[:, None]))
             fisher_pval = fisher_test(pvals)
             if fisher_pval >= alpha:
                 tmp_clusters_list.append(cluster)
@@ -66,13 +75,13 @@ def GIN(data, indep_test_method='kci', alpha=0.05):
             var_set -= set(cluster)
         cluster_size += 1
 
-    K = []
+    causal_order = [] # this variable corresponds to K in paper
     updated = True
     while updated:
         updated = False
         X = []
         Z = []
-        for cluster_k in K:
+        for cluster_k in causal_order:
             cluster_k1, cluster_k2 = array_split(cluster_k, 2)
             X += cluster_k1
             Z += cluster_k2
@@ -87,13 +96,13 @@ def GIN(data, indep_test_method='kci', alpha=0.05):
                 e = cal_e_with_gin(data, cov, X + cluster_i1 + cluster_j1, Z + cluster_i2)
                 pvals = []
                 for z in range(len(Z + cluster_i2)):
-                    pvals.append(indep_test.compute_pvalue(data[:, [z]], e[:, None])[0])
+                    pvals.append(indep_test(data[:, [z]], e[:, None]))
                 fisher_pval = fisher_test(pvals)
                 if fisher_pval < alpha:
                     is_root = False
                     break
             if is_root:
-                K.append(cluster_i)
+                causal_order.append(cluster_i)
                 clusters_list.remove(cluster_i)
                 updated = True
                 break
@@ -106,7 +115,7 @@ def GIN(data, indep_test_method='kci', alpha=0.05):
     latent_id = 1
     l_nodes = []
 
-    for cluster in K:
+    for cluster in causal_order:
         l_node = GraphNode(f"L{latent_id}")
         l_node.set_node_type(NodeType.LATENT)
         G.add_node(l_node)
@@ -140,7 +149,7 @@ def GIN(data, indep_test_method='kci', alpha=0.05):
             G.add_directed_edge(l_node, o_node)
         latent_id += 1
 
-    return G, K
+    return G, causal_order
 
 
 def GIN_MI(data):
@@ -157,7 +166,7 @@ def GIN_MI(data):
     -------
     G : general graph
         causal graph
-    K : list
+    causal_order : list
         causal order
     '''
     v_labels = list(range(data.shape[1]))
@@ -182,16 +191,16 @@ def GIN_MI(data):
     cluster_list = merge_overlaping_cluster(cluster_list)
 
     # Step 2: Learning the Causal Order of Latent Variables
-    K = []
+    causal_order = [] # this variable corresponds to K in paper
     while (len(cluster_list) != 0):
-        root = find_root(data, cov, cluster_list, K)
-        K.append(root)
+        root = find_root(data, cov, cluster_list, causal_order)
+        causal_order.append(root)
         cluster_list.remove(root)
 
     latent_id = 1
     l_nodes = []
     G = GeneralGraph([])
-    for cluster in K:
+    for cluster in causal_order:
         l_node = GraphNode(f"L{latent_id}")
         l_node.set_node_type(NodeType.LATENT)
         l_nodes.append(l_node)
@@ -205,14 +214,14 @@ def GIN_MI(data):
             G.add_directed_edge(l_node, o_node)
         latent_id += 1
 
-    return G, K
+    return G, causal_order
 
 
 def cal_e_with_gin(data, cov, X, Z):
     cov_m = cov[np.ix_(Z, X)]
     _, _, v = np.linalg.svd(cov_m)
     omega = v.T[:, -1]
-    return np.dot(data[:, X], omega.T)
+    return np.dot(data[:, X], omega)
 
 
 def cal_dep_for_gin(data, cov, X, Z):
@@ -240,7 +249,7 @@ def cal_dep_for_gin(data, cov, X, Z):
     return sta
 
 
-def find_root(data, cov, clusters, K):
+def find_root(data, cov, clusters, causal_order):
     '''
     Find the causal order by statistics of dependence
     Parameters
@@ -248,7 +257,7 @@ def find_root(data, cov, clusters, K):
     data : data set (numpy ndarray)
     cov : covariance matrix
     clusters : clusters of observed variables
-    K : causal order
+    causal_order : causal order
     Returns
     -------
     root : latent root cause
@@ -266,8 +275,8 @@ def find_root(data, cov, clusters, K):
             for k in range(1, len(i)):
                 Z.append(i[k])
 
-            if K:
-                for k in K:
+            if causal_order:
+                for k in causal_order:
                     X.append(k[0])
                     Z.append(k[1])
 

--- a/tests/TestGIN.py
+++ b/tests/TestGIN.py
@@ -1,104 +1,81 @@
 import random
-import sys
-import io
-
-sys.path.append("")
 import unittest
 
 import numpy as np
-import matplotlib.image as mpimg
-import matplotlib.pyplot as plt
 
 from causallearn.search.HiddenCausal.GIN.GIN import GIN
 
 
 class TestGIN(unittest.TestCase):
     def test_case1(self):
-        sample_size = 1000
-        np.random.seed(0)
-        L1 = np.random.uniform(-1, 1, size=sample_size) ** 5
-        L2 = np.random.uniform(0.5, 2.0) * L1 + np.random.uniform(-1, 1, size=sample_size) ** 5
-        X1 = np.random.uniform(0.5, 2.0) * L1 + np.random.uniform(-1, 1, size=sample_size) ** 5
-        X2 = np.random.uniform(0.5, 2.0) * L1 + np.random.uniform(-1, 1, size=sample_size) ** 5
-        X3 = np.random.uniform(0.5, 2.0) * L2 + np.random.uniform(-1, 1, size=sample_size) ** 5
-        X4 = np.random.uniform(0.5, 2.0) * L2 + np.random.uniform(-1, 1, size=sample_size) ** 5
-
-        data = np.array([X1, X2, X3, X4]).T
-        data = (data - np.mean(data, axis=0)) / np.std(data, axis=0)
-        g, k = GIN(data)
-        print(g, k)
-
-        # Visualization using pydot
-        from causallearn.utils.GraphUtils import GraphUtils
-        pyd = GraphUtils.to_pydot(g)
-        tmp_png = pyd.create_png(f="png")
-        fp = io.BytesIO(tmp_png)
-        img = mpimg.imread(fp, format='png')
-        plt.axis('off')
-        plt.imshow(img)
-        plt.show()
-
-    def test_case2(self):
-        sample_size = 1000
-        np.random.seed(0)
-        L1 = np.random.uniform(-1, 1, size=sample_size) ** 5
-        L2 = np.random.uniform(0.5, 2.0) * L1 + np.random.uniform(-1, 1, size=sample_size) ** 5
-        L3 = np.random.uniform(0.5, 2.0) * L1 + np.random.uniform(0.5, 2.0) * L2 + np.random.uniform(-1, 1,
-                                                                                                     size=sample_size) ** 5
-        X1 = np.random.uniform(0.5, 2.0) * L1 + np.random.uniform(-1, 1, size=sample_size) ** 5
-        X2 = np.random.uniform(0.5, 2.0) * L1 + np.random.uniform(-1, 1, size=sample_size) ** 5
-        X3 = np.random.uniform(0.5, 2.0) * L1 + np.random.uniform(-1, 1, size=sample_size) ** 5
-        X4 = np.random.uniform(0.5, 2.0) * L2 + np.random.uniform(-1, 1, size=sample_size) ** 5
-        X5 = np.random.uniform(0.5, 2.0) * L2 + np.random.uniform(-1, 1, size=sample_size) ** 5
-        X6 = np.random.uniform(0.5, 2.0) * L2 + np.random.uniform(-1, 1, size=sample_size) ** 5
-        X7 = np.random.uniform(0.5, 2.0) * L3 + np.random.uniform(-1, 1, size=sample_size) ** 5
-        X8 = np.random.uniform(0.5, 2.0) * L3 + np.random.uniform(-1, 1, size=sample_size) ** 5
-        X9 = np.random.uniform(0.5, 2.0) * L3 + np.random.uniform(-1, 1, size=sample_size) ** 5
-
-        data = np.array([X1, X2, X3, X4, X5, X6, X7, X8, X9]).T
-        data = (data - np.mean(data, axis=0)) / np.std(data, axis=0)
-        g, k = GIN(data)
-        print(g, k)
-
-        # Visualization using pydot
-        from causallearn.utils.GraphUtils import GraphUtils
-        pyd = GraphUtils.to_pydot(g)
-        tmp_png = pyd.create_png(f="png")
-        fp = io.BytesIO(tmp_png)
-        img = mpimg.imread(fp, format='png')
-        plt.axis('off')
-        plt.imshow(img)
-        plt.show()
-
-    def test_case3(self):
-        sample_size = 1000
+        sample_size = 500
         random.seed(42)
         np.random.seed(42)
-        L1 = np.random.uniform(-1, 1, size=sample_size) ** 5
-        L2 = np.random.uniform(0.5, 2.0) * L1 + np.random.uniform(-1, 1, size=sample_size) ** 5
-        L3 = np.random.uniform(0.5, 2.0) * L1 + np.random.uniform(0.5, 2.0) * L2 + np.random.uniform(-1, 1, size=sample_size) ** 5
-        L4 = np.random.uniform(0.5, 2.0) * L1 + np.random.uniform(0.5, 2.0) * L2 + np.random.uniform(0.5, 2.0) * L3 + np.random.uniform(-1, 1, size=sample_size) ** 5
+        L1 = np.random.uniform(-1, 1, size=sample_size)
+        L2 = np.random.uniform(1.2, 1.8) * L1 + np.random.uniform(-1, 1, size=sample_size)
+        X1 = np.random.uniform(1.2, 1.8) * L1 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X2 = np.random.uniform(1.2, 1.8) * L1 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X3 = np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X4 = np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        data = np.array([X1, X2, X3, X4]).T
+        data = (data - np.mean(data, axis=0)) / np.std(data, axis=0)
+        _, k = GIN(data)
+        k = [sorted(i) for i in k]
+        ground_truth = [[0, 1], [2, 3]]
+        assert len(k) == len(ground_truth)
+        for i in range(len(k)):
+            assert np.isclose(k[i], ground_truth[i]).all()
 
-        X1 = np.random.uniform(0.5, 2.0) * L1 + np.random.uniform(0.5, 2.0) * L2 + np.random.uniform(-1, 1, size=sample_size) ** 5
-        X2 = np.random.uniform(0.5, 2.0) * L1 + np.random.uniform(0.5, 2.0) * L2 + np.random.uniform(-1, 1, size=sample_size) ** 5
-        X3 = np.random.uniform(0.5, 2.0) * L1 + np.random.uniform(0.5, 2.0) * L2 + np.random.uniform(-1, 1, size=sample_size) ** 5
-        X4 = np.random.uniform(0.5, 2.0) * L1 + np.random.uniform(0.5, 2.0) * L2 + np.random.uniform(-1, 1, size=sample_size) ** 5
-        X5 = np.random.uniform(0.5, 2.0) * L3 + np.random.uniform(-1, 1, size=sample_size) ** 5
-        X6 = np.random.uniform(0.5, 2.0) * L3 + np.random.uniform(-1, 1, size=sample_size) ** 5
-        X7 = np.random.uniform(0.5, 2.0) * L4 + np.random.uniform(-1, 1, size=sample_size) ** 5
-        X8 = np.random.uniform(0.5, 2.0) * L4 + np.random.uniform(-1, 1, size=sample_size) ** 5
+
+    def test_case2(self):
+        sample_size = 500
+        random.seed(42)
+        np.random.seed(42)
+        L1 = np.random.uniform(-1, 1, size=sample_size)
+        L2 = np.random.uniform(1.2, 1.8) * L1 + np.random.uniform(-1, 1, size=sample_size)
+        L3 = np.random.uniform(1.2, 1.8) * L1 + np.random.uniform(1.2, 1.8) * L2 + np.random.uniform(-1, 1, size=sample_size)
+        X1 = np.random.uniform(1.2, 1.8) * L1 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X2 = np.random.uniform(1.2, 1.8) * L1 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X3 = np.random.uniform(1.2, 1.8) * L1 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X4 = np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X5 = np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X6 = np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X7 = np.random.uniform(1.2, 1.8) * L3 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X8 = np.random.uniform(1.2, 1.8) * L3 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X9 = np.random.uniform(1.2, 1.8) * L3 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        data = np.array([X1, X2, X3, X4, X5, X6, X7, X8, X9]).T
+        data = (data - np.mean(data, axis=0)) / np.std(data, axis=0)
+        _, k = GIN(data)
+        k = [sorted(k_i) for k_i in k]
+        ground_truth = [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
+        assert len(k) == len(ground_truth)
+        for i in range(len(k)):
+            assert np.isclose(k[i], ground_truth[i]).all()
+
+
+    def test_case3(self):
+        sample_size = 500
+        random.seed(0)
+        np.random.seed(0)
+        L1 = np.random.uniform(-1, 1, size=sample_size)
+        L2 = np.random.uniform(1.2, 1.8) * L1 + np.random.uniform(-1, 1, size=sample_size)
+        L3 = np.random.uniform(0.5, 0.8) * L1 + np.random.uniform(0.5, 0.8) * L2 + np.random.uniform(-1, 1, size=sample_size)
+        L4 = np.random.uniform(0.5, 0.8) * L1 + np.random.uniform(0.5, 0.8) * L2 + np.random.uniform(1.2, 1.8) * L3 + np.random.uniform(-1, 1, size=sample_size)
+
+        X1 = np.random.uniform(1.2, 1.8) * L1 + np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X2 = np.random.uniform(1.2, 1.8) * L1 + np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X3 = np.random.uniform(1.2, 1.8) * L1 + np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X4 = np.random.uniform(1.2, 1.8) * L1 + np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X5 = np.random.uniform(1.2, 1.8) * L3 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X6 = np.random.uniform(1.2, 1.8) * L3 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X7 = np.random.uniform(1.2, 1.8) * L4 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X8 = np.random.uniform(1.2, 1.8) * L4 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+
 
         data = np.array([X1, X2, X3, X4, X5, X6, X7, X8]).T
         data = (data - np.mean(data, axis=0)) / np.std(data, axis=0)
         g, k = GIN(data)
-        print(g, k)
-
-        # Visualization using pydot
-        from causallearn.utils.GraphUtils import GraphUtils
-        pyd = GraphUtils.to_pydot(g)
-        tmp_png = pyd.create_png(f="png")
-        fp = io.BytesIO(tmp_png)
-        img = mpimg.imread(fp, format='png')
-        plt.axis('off')
-        plt.imshow(img)
-        plt.show()
+        k = [sorted(k_i) for k_i in k]
+        ground_truth = [[0, 1, 2, 3], [4, 5], [6, 7]]
+        for i in range(len(k)):
+            assert np.isclose(k[i], ground_truth[i]).all()

--- a/tests/TestGIN.py
+++ b/tests/TestGIN.py
@@ -7,7 +7,7 @@ from causallearn.search.HiddenCausal.GIN.GIN import GIN
 
 
 class TestGIN(unittest.TestCase):
-    def test_case1(self):
+    def test_case1_kci(self):
         sample_size = 500
         random.seed(42)
         np.random.seed(42)
@@ -19,15 +19,33 @@ class TestGIN(unittest.TestCase):
         X4 = np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
         data = np.array([X1, X2, X3, X4]).T
         data = (data - np.mean(data, axis=0)) / np.std(data, axis=0)
-        _, k = GIN(data)
-        k = [sorted(i) for i in k]
+        _, causal_order = GIN(data, indep_test_method='kci')
+        causal_order = [sorted(cluster_i) for cluster_i in causal_order]
         ground_truth = [[0, 1], [2, 3]]
-        assert len(k) == len(ground_truth)
-        for i in range(len(k)):
-            assert np.isclose(k[i], ground_truth[i]).all()
+        assert len(causal_order) == len(ground_truth)
+        for i in range(len(causal_order)):
+            assert np.isclose(causal_order[i], ground_truth[i]).all()
 
+    def test_case1_hsic(self):
+        sample_size = 500
+        random.seed(42)
+        np.random.seed(42)
+        L1 = np.random.uniform(-1, 1, size=sample_size)
+        L2 = np.random.uniform(1.2, 1.8) * L1 + np.random.uniform(-1, 1, size=sample_size)
+        X1 = np.random.uniform(1.2, 1.8) * L1 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X2 = np.random.uniform(1.2, 1.8) * L1 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X3 = np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X4 = np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        data = np.array([X1, X2, X3, X4]).T
+        data = (data - np.mean(data, axis=0)) / np.std(data, axis=0)
+        _, causal_order = GIN(data, indep_test_method='hsic')
+        causal_order = [sorted(cluster_i) for cluster_i in causal_order]
+        ground_truth = [[0, 1], [2, 3]]
+        assert len(causal_order) == len(ground_truth)
+        for i in range(len(causal_order)):
+            assert np.isclose(causal_order[i], ground_truth[i]).all()
 
-    def test_case2(self):
+    def test_case2_kci(self):
         sample_size = 500
         random.seed(42)
         np.random.seed(42)
@@ -45,15 +63,40 @@ class TestGIN(unittest.TestCase):
         X9 = np.random.uniform(1.2, 1.8) * L3 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
         data = np.array([X1, X2, X3, X4, X5, X6, X7, X8, X9]).T
         data = (data - np.mean(data, axis=0)) / np.std(data, axis=0)
-        _, k = GIN(data)
-        k = [sorted(k_i) for k_i in k]
+        _, causal_order = GIN(data, indep_test_method='kci')
+        causal_order = [sorted(cluster_i) for cluster_i in causal_order]
         ground_truth = [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
-        assert len(k) == len(ground_truth)
-        for i in range(len(k)):
-            assert np.isclose(k[i], ground_truth[i]).all()
+        assert len(causal_order) == len(ground_truth)
+        for i in range(len(causal_order)):
+            assert np.isclose(causal_order[i], ground_truth[i]).all()
+
+    def test_case2_hsic(self):
+        sample_size = 500
+        random.seed(42)
+        np.random.seed(42)
+        L1 = np.random.uniform(-1, 1, size=sample_size)
+        L2 = np.random.uniform(1.2, 1.8) * L1 + np.random.uniform(-1, 1, size=sample_size)
+        L3 = np.random.uniform(1.2, 1.8) * L1 + np.random.uniform(1.2, 1.8) * L2 + np.random.uniform(-1, 1, size=sample_size)
+        X1 = np.random.uniform(1.2, 1.8) * L1 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X2 = np.random.uniform(1.2, 1.8) * L1 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X3 = np.random.uniform(1.2, 1.8) * L1 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X4 = np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X5 = np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X6 = np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X7 = np.random.uniform(1.2, 1.8) * L3 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X8 = np.random.uniform(1.2, 1.8) * L3 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X9 = np.random.uniform(1.2, 1.8) * L3 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        data = np.array([X1, X2, X3, X4, X5, X6, X7, X8, X9]).T
+        data = (data - np.mean(data, axis=0)) / np.std(data, axis=0)
+        _, causal_order = GIN(data, indep_test_method='hsic')
+        causal_order = [sorted(cluster_i) for cluster_i in causal_order]
+        ground_truth = [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
+        assert len(causal_order) == len(ground_truth)
+        for i in range(len(causal_order)):
+            assert np.isclose(causal_order[i], ground_truth[i]).all()
 
 
-    def test_case3(self):
+    def test_case3_kci(self):
         sample_size = 500
         random.seed(0)
         np.random.seed(0)
@@ -74,8 +117,36 @@ class TestGIN(unittest.TestCase):
 
         data = np.array([X1, X2, X3, X4, X5, X6, X7, X8]).T
         data = (data - np.mean(data, axis=0)) / np.std(data, axis=0)
-        g, k = GIN(data)
-        k = [sorted(k_i) for k_i in k]
+        _, causal_order = GIN(data, indep_test_method='kci')
+        causal_order = [sorted(cluster_i) for cluster_i in causal_order]
         ground_truth = [[0, 1, 2, 3], [4, 5], [6, 7]]
-        for i in range(len(k)):
-            assert np.isclose(k[i], ground_truth[i]).all()
+        for i in range(len(causal_order)):
+            assert np.isclose(causal_order[i], ground_truth[i]).all()
+
+
+    def test_case3_hsic(self):
+        sample_size = 500
+        random.seed(0)
+        np.random.seed(0)
+        L1 = np.random.uniform(-1, 1, size=sample_size)
+        L2 = np.random.uniform(1.2, 1.8) * L1 + np.random.uniform(-1, 1, size=sample_size)
+        L3 = np.random.uniform(0.5, 0.8) * L1 + np.random.uniform(0.5, 0.8) * L2 + np.random.uniform(-1, 1, size=sample_size)
+        L4 = np.random.uniform(0.5, 0.8) * L1 + np.random.uniform(0.5, 0.8) * L2 + np.random.uniform(1.2, 1.8) * L3 + np.random.uniform(-1, 1, size=sample_size)
+
+        X1 = np.random.uniform(1.2, 1.8) * L1 + np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X2 = np.random.uniform(1.2, 1.8) * L1 + np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X3 = np.random.uniform(1.2, 1.8) * L1 + np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X4 = np.random.uniform(1.2, 1.8) * L1 + np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X5 = np.random.uniform(1.2, 1.8) * L3 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X6 = np.random.uniform(1.2, 1.8) * L3 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X7 = np.random.uniform(1.2, 1.8) * L4 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+        X8 = np.random.uniform(1.2, 1.8) * L4 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
+
+
+        data = np.array([X1, X2, X3, X4, X5, X6, X7, X8]).T
+        data = (data - np.mean(data, axis=0)) / np.std(data, axis=0)
+        _, causal_order = GIN(data, indep_test_method='hsic')
+        causal_order = [sorted(cluster_i) for cluster_i in causal_order]
+        ground_truth = [[0, 1, 2, 3], [4, 5], [6, 7]]
+        for i in range(len(causal_order)):
+            assert np.isclose(causal_order[i], ground_truth[i]).all()

--- a/tests/TestGIN.py
+++ b/tests/TestGIN.py
@@ -7,7 +7,9 @@ from causallearn.search.HiddenCausal.GIN.GIN import GIN
 
 
 class TestGIN(unittest.TestCase):
-    def test_case1_kci(self):
+    indep_test_methods = ['kci', 'hsic']
+
+    def test_case1(self):
         sample_size = 500
         random.seed(42)
         np.random.seed(42)
@@ -19,33 +21,13 @@ class TestGIN(unittest.TestCase):
         X4 = np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
         data = np.array([X1, X2, X3, X4]).T
         data = (data - np.mean(data, axis=0)) / np.std(data, axis=0)
-        _, causal_order = GIN(data, indep_test_method='kci')
-        causal_order = [sorted(cluster_i) for cluster_i in causal_order]
-        ground_truth = [[0, 1], [2, 3]]
-        assert len(causal_order) == len(ground_truth)
-        for i in range(len(causal_order)):
-            assert np.isclose(causal_order[i], ground_truth[i]).all()
 
-    def test_case1_hsic(self):
-        sample_size = 500
-        random.seed(42)
-        np.random.seed(42)
-        L1 = np.random.uniform(-1, 1, size=sample_size)
-        L2 = np.random.uniform(1.2, 1.8) * L1 + np.random.uniform(-1, 1, size=sample_size)
-        X1 = np.random.uniform(1.2, 1.8) * L1 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
-        X2 = np.random.uniform(1.2, 1.8) * L1 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
-        X3 = np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
-        X4 = np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
-        data = np.array([X1, X2, X3, X4]).T
-        data = (data - np.mean(data, axis=0)) / np.std(data, axis=0)
-        _, causal_order = GIN(data, indep_test_method='hsic')
-        causal_order = [sorted(cluster_i) for cluster_i in causal_order]
         ground_truth = [[0, 1], [2, 3]]
-        assert len(causal_order) == len(ground_truth)
-        for i in range(len(causal_order)):
-            assert np.isclose(causal_order[i], ground_truth[i]).all()
 
-    def test_case2_kci(self):
+        TestGIN.run_gin_test(data, ground_truth, 0.05)
+
+
+    def test_case2(self):
         sample_size = 500
         random.seed(42)
         np.random.seed(42)
@@ -63,40 +45,13 @@ class TestGIN(unittest.TestCase):
         X9 = np.random.uniform(1.2, 1.8) * L3 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
         data = np.array([X1, X2, X3, X4, X5, X6, X7, X8, X9]).T
         data = (data - np.mean(data, axis=0)) / np.std(data, axis=0)
-        _, causal_order = GIN(data, indep_test_method='kci')
-        causal_order = [sorted(cluster_i) for cluster_i in causal_order]
+
         ground_truth = [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
-        assert len(causal_order) == len(ground_truth)
-        for i in range(len(causal_order)):
-            assert np.isclose(causal_order[i], ground_truth[i]).all()
 
-    def test_case2_hsic(self):
-        sample_size = 500
-        random.seed(42)
-        np.random.seed(42)
-        L1 = np.random.uniform(-1, 1, size=sample_size)
-        L2 = np.random.uniform(1.2, 1.8) * L1 + np.random.uniform(-1, 1, size=sample_size)
-        L3 = np.random.uniform(1.2, 1.8) * L1 + np.random.uniform(1.2, 1.8) * L2 + np.random.uniform(-1, 1, size=sample_size)
-        X1 = np.random.uniform(1.2, 1.8) * L1 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
-        X2 = np.random.uniform(1.2, 1.8) * L1 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
-        X3 = np.random.uniform(1.2, 1.8) * L1 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
-        X4 = np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
-        X5 = np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
-        X6 = np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
-        X7 = np.random.uniform(1.2, 1.8) * L3 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
-        X8 = np.random.uniform(1.2, 1.8) * L3 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
-        X9 = np.random.uniform(1.2, 1.8) * L3 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
-        data = np.array([X1, X2, X3, X4, X5, X6, X7, X8, X9]).T
-        data = (data - np.mean(data, axis=0)) / np.std(data, axis=0)
-        _, causal_order = GIN(data, indep_test_method='hsic')
-        causal_order = [sorted(cluster_i) for cluster_i in causal_order]
-        ground_truth = [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
-        assert len(causal_order) == len(ground_truth)
-        for i in range(len(causal_order)):
-            assert np.isclose(causal_order[i], ground_truth[i]).all()
+        TestGIN.run_gin_test(data, ground_truth, 0.05)
 
 
-    def test_case3_kci(self):
+    def test_case3(self):
         sample_size = 500
         random.seed(0)
         np.random.seed(0)
@@ -104,7 +59,6 @@ class TestGIN(unittest.TestCase):
         L2 = np.random.uniform(1.2, 1.8) * L1 + np.random.uniform(-1, 1, size=sample_size)
         L3 = np.random.uniform(0.5, 0.8) * L1 + np.random.uniform(0.5, 0.8) * L2 + np.random.uniform(-1, 1, size=sample_size)
         L4 = np.random.uniform(0.5, 0.8) * L1 + np.random.uniform(0.5, 0.8) * L2 + np.random.uniform(1.2, 1.8) * L3 + np.random.uniform(-1, 1, size=sample_size)
-
         X1 = np.random.uniform(1.2, 1.8) * L1 + np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
         X2 = np.random.uniform(1.2, 1.8) * L1 + np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
         X3 = np.random.uniform(1.2, 1.8) * L1 + np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
@@ -113,42 +67,22 @@ class TestGIN(unittest.TestCase):
         X6 = np.random.uniform(1.2, 1.8) * L3 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
         X7 = np.random.uniform(1.2, 1.8) * L4 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
         X8 = np.random.uniform(1.2, 1.8) * L4 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
-
-
         data = np.array([X1, X2, X3, X4, X5, X6, X7, X8]).T
         data = (data - np.mean(data, axis=0)) / np.std(data, axis=0)
-        _, causal_order = GIN(data, indep_test_method='kci')
-        causal_order = [sorted(cluster_i) for cluster_i in causal_order]
+
         ground_truth = [[0, 1, 2, 3], [4, 5], [6, 7]]
-        assert len(causal_order) == len(ground_truth)
-        for i in range(len(causal_order)):
-            assert np.isclose(causal_order[i], ground_truth[i]).all()
 
+        TestGIN.run_gin_test(data, ground_truth, 0.05)
 
-    def test_case3_hsic(self):
-        sample_size = 500
-        random.seed(0)
-        np.random.seed(0)
-        L1 = np.random.uniform(-1, 1, size=sample_size)
-        L2 = np.random.uniform(1.2, 1.8) * L1 + np.random.uniform(-1, 1, size=sample_size)
-        L3 = np.random.uniform(0.5, 0.8) * L1 + np.random.uniform(0.5, 0.8) * L2 + np.random.uniform(-1, 1, size=sample_size)
-        L4 = np.random.uniform(0.5, 0.8) * L1 + np.random.uniform(0.5, 0.8) * L2 + np.random.uniform(1.2, 1.8) * L3 + np.random.uniform(-1, 1, size=sample_size)
+    @staticmethod
+    def run_gin_test(data, ground_truth, alpha):
+        for indep_test_method in TestGIN.indep_test_methods:
+            _, causal_order = GIN(data, indep_test_method=indep_test_method, alpha=alpha)
+            causal_order = [sorted(cluster_i) for cluster_i in causal_order]
+            TestGIN.validate_result(ground_truth, causal_order)
 
-        X1 = np.random.uniform(1.2, 1.8) * L1 + np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
-        X2 = np.random.uniform(1.2, 1.8) * L1 + np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
-        X3 = np.random.uniform(1.2, 1.8) * L1 + np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
-        X4 = np.random.uniform(1.2, 1.8) * L1 + np.random.uniform(1.2, 1.8) * L2 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
-        X5 = np.random.uniform(1.2, 1.8) * L3 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
-        X6 = np.random.uniform(1.2, 1.8) * L3 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
-        X7 = np.random.uniform(1.2, 1.8) * L4 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
-        X8 = np.random.uniform(1.2, 1.8) * L4 + 0.2 * np.random.uniform(-1, 1, size=sample_size)
-
-
-        data = np.array([X1, X2, X3, X4, X5, X6, X7, X8]).T
-        data = (data - np.mean(data, axis=0)) / np.std(data, axis=0)
-        _, causal_order = GIN(data, indep_test_method='hsic')
-        causal_order = [sorted(cluster_i) for cluster_i in causal_order]
-        ground_truth = [[0, 1, 2, 3], [4, 5], [6, 7]]
-        assert len(causal_order) == len(ground_truth)
-        for i in range(len(causal_order)):
-            assert np.isclose(causal_order[i], ground_truth[i]).all()
+    @staticmethod
+    def validate_result(ground_truth, estimated_result):
+        assert len(ground_truth) == len(estimated_result)
+        for i in range(len(estimated_result)):
+            assert np.isclose(estimated_result[i], ground_truth[i]).all()

--- a/tests/TestGIN.py
+++ b/tests/TestGIN.py
@@ -120,6 +120,7 @@ class TestGIN(unittest.TestCase):
         _, causal_order = GIN(data, indep_test_method='kci')
         causal_order = [sorted(cluster_i) for cluster_i in causal_order]
         ground_truth = [[0, 1, 2, 3], [4, 5], [6, 7]]
+        assert len(causal_order) == len(ground_truth)
         for i in range(len(causal_order)):
             assert np.isclose(causal_order[i], ground_truth[i]).all()
 
@@ -148,5 +149,6 @@ class TestGIN(unittest.TestCase):
         _, causal_order = GIN(data, indep_test_method='hsic')
         causal_order = [sorted(cluster_i) for cluster_i in causal_order]
         ground_truth = [[0, 1, 2, 3], [4, 5], [6, 7]]
+        assert len(causal_order) == len(ground_truth)
         for i in range(len(causal_order)):
             assert np.isclose(causal_order[i], ground_truth[i]).all()

--- a/tests/TestGIN.py
+++ b/tests/TestGIN.py
@@ -85,4 +85,4 @@ class TestGIN(unittest.TestCase):
     def validate_result(ground_truth, estimated_result):
         assert len(ground_truth) == len(estimated_result)
         for i in range(len(estimated_result)):
-            assert np.isclose(estimated_result[i], ground_truth[i]).all()
+            assert estimated_result[i] == ground_truth[i]


### PR DESCRIPTION
## Description
The GIN algorithm returns the graph and the causal order. In this algorithm, the causal order and the causal graph correspond to each other, so only the causal order in the result is asserted.

## Updates

- Fixed the independence test problem in GIN
- Added assertion to the previous test cases
- Removed the plot function in previous test cases for GIN
- Added tests to test GIN algorithm using the hsic independence test.
- Updated docstring
- Removed default parameter of indep_test
- Refactored the test code

## Test Plan

```python
python -m unittest tests.TestGIN # should pass
```
![image](https://user-images.githubusercontent.com/83860323/180476878-47a93277-d5b7-4688-8591-d1d6e5b280cc.png)
