### PR TITLE
Added a local cache resume example in TestPC

### DIFF
--- a/causallearn/search/ConstraintBased/CDNOD.py
+++ b/causallearn/search/ConstraintBased/CDNOD.py
@@ -16,7 +16,7 @@ from causallearn.search.ConstraintBased.PC import get_parent_missingness_pairs, 
 def cdnod(data: ndarray, c_indx: ndarray, alpha: float=0.05, indep_test: str=fisherz, stable: bool=True,
           uc_rule: int=0, uc_priority: int=2, mvcdnod: bool=False, correction_name: str='MV_Crtn_Fisher_Z',
           background_knowledge: Optional[BackgroundKnowledge]=None, verbose: bool=False,
-          show_progress: bool = True) -> CausalGraph:
+          show_progress: bool = True, **kwargs) -> CausalGraph:
     """
     Causal discovery from nonstationary/heterogeneous data
     phase 1: learning causal skeleton,
@@ -37,16 +37,16 @@ def cdnod(data: ndarray, c_indx: ndarray, alpha: float=0.05, indep_test: str=fis
     if mvcdnod:
         return mvcdnod_alg(data=data_aug, alpha=alpha, indep_test=indep_test, correction_name=correction_name,
                            stable=stable, uc_rule=uc_rule, uc_priority=uc_priority, verbose=verbose,
-                           show_progress=show_progress)
+                           show_progress=show_progress, **kwargs)
     else:
         return cdnod_alg(data=data_aug, alpha=alpha, indep_test=indep_test, stable=stable, uc_rule=uc_rule,
                          uc_priority=uc_priority, background_knowledge=background_knowledge, verbose=verbose,
-                         show_progress=show_progress)
+                         show_progress=show_progress, **kwargs)
 
 
 def cdnod_alg(data: ndarray, alpha: float, indep_test: str, stable: bool, uc_rule: int, uc_priority: int,
               background_knowledge: Optional[BackgroundKnowledge] = None, verbose: bool = False,
-              show_progress: bool = True) -> CausalGraph:
+              show_progress: bool = True, **kwargs) -> CausalGraph:
     """
     Perform Peter-Clark algorithm for causal discovery on the augmented data set that captures the unobserved changing factors
 
@@ -85,7 +85,7 @@ def cdnod_alg(data: ndarray, alpha: float, indep_test: str, stable: bool, uc_rul
 
     """
     start = time.time()
-    indep_test = CIT(data, indep_test)
+    indep_test = CIT(data, indep_test, **kwargs)
     cg_1 = SkeletonDiscovery.skeleton_discovery(data, alpha, indep_test, stable)
 
     # orient the direction from c_indx to X, if there is an edge between c_indx and X
@@ -127,7 +127,7 @@ def cdnod_alg(data: ndarray, alpha: float, indep_test: str, stable: bool, uc_rul
 
 
 def mvcdnod_alg(data: ndarray, alpha: float, indep_test: str, correction_name: str, stable: bool, uc_rule: int,
-                uc_priority: int, verbose: bool, show_progress: bool) -> CausalGraph:
+                uc_priority: int, verbose: bool, show_progress: bool, **kwargs) -> CausalGraph:
     """
     :param data: data set (numpy ndarray)
     :param alpha: desired significance level (float) in (0, 1)
@@ -156,7 +156,7 @@ def mvcdnod_alg(data: ndarray, alpha: float, indep_test: str, correction_name: s
     """
 
     start = time.time()
-    indep_test = CIT(data, indep_test)
+    indep_test = CIT(data, indep_test, **kwargs)
     ## Step 1: detect the direct causes of missingness indicators
     prt_m = get_parent_missingness_pairs(data, alpha, indep_test, stable)
     # print('Finish detecting the parents of missingness indicators.  ')

--- a/causallearn/search/ConstraintBased/FCI.py
+++ b/causallearn/search/ConstraintBased/FCI.py
@@ -729,7 +729,8 @@ def get_color_edges(graph: Graph) -> List[Edge]:
 
 
 def fci(dataset: ndarray, independence_test_method: str=fisherz, alpha: float = 0.05, depth: int = -1,
-        max_path_length: int = -1, verbose: bool = False, background_knowledge: BackgroundKnowledge | None = None) -> Tuple[Graph, List[Edge]]:
+        max_path_length: int = -1, verbose: bool = False, background_knowledge: BackgroundKnowledge | None = None,
+        **kwargs) -> Tuple[Graph, List[Edge]]:
     """
     Perform Fast Causal Inference (FCI) algorithm for causal discovery
 
@@ -766,7 +767,7 @@ def fci(dataset: ndarray, independence_test_method: str=fisherz, alpha: float = 
     if dataset.shape[0] < dataset.shape[1]:
         warnings.warn("The number of features is much larger than the sample size!")
 
-    independence_test_method = CIT(dataset, method=independence_test_method)
+    independence_test_method = CIT(dataset, method=independence_test_method, **kwargs)
 
     ## ------- check parameters ------------
     if (depth is None) or type(depth) != int:

--- a/causallearn/search/ConstraintBased/PC.py
+++ b/causallearn/search/ConstraintBased/PC.py
@@ -29,7 +29,8 @@ def pc(
     background_knowledge: BackgroundKnowledge | None = None, 
     verbose: bool = False, 
     show_progress: bool = True,
-    node_names: List[str] | None = None, 
+    node_names: List[str] | None = None,
+    **kwargs
 ):
     if data.shape[0] < data.shape[1]:
         warnings.warn("The number of features is much larger than the sample size!")
@@ -40,11 +41,11 @@ def pc(
         return mvpc_alg(data=data, node_names=node_names, alpha=alpha, indep_test=indep_test, correction_name=correction_name, stable=stable,
                         uc_rule=uc_rule, uc_priority=uc_priority, background_knowledge=background_knowledge,
                         verbose=verbose,
-                        show_progress=show_progress)
+                        show_progress=show_progress, **kwargs)
     else:
         return pc_alg(data=data, node_names=node_names, alpha=alpha, indep_test=indep_test, stable=stable, uc_rule=uc_rule,
                       uc_priority=uc_priority, background_knowledge=background_knowledge, verbose=verbose,
-                      show_progress=show_progress)
+                      show_progress=show_progress, **kwargs)
 
 
 def pc_alg(
@@ -58,6 +59,7 @@ def pc_alg(
     background_knowledge: BackgroundKnowledge | None = None,
     verbose: bool = False,
     show_progress: bool = True,
+    **kwargs
 ) -> CausalGraph:
     """
     Perform Peter-Clark (PC) algorithm for causal discovery
@@ -98,7 +100,7 @@ def pc_alg(
     """
 
     start = time.time()
-    indep_test = CIT(data, indep_test)
+    indep_test = CIT(data, indep_test, **kwargs)
     cg_1 = SkeletonDiscovery.skeleton_discovery(data, alpha, indep_test, stable,
                                                 background_knowledge=background_knowledge, verbose=verbose,
                                                 show_progress=show_progress, node_names=node_names)
@@ -148,6 +150,7 @@ def mvpc_alg(
     background_knowledge: BackgroundKnowledge | None = None,
     verbose: bool = False,
     show_progress: bool = True,
+    **kwargs,
 ) -> CausalGraph:
     """
     Perform missing value Peter-Clark (PC) algorithm for causal discovery
@@ -192,7 +195,7 @@ def mvpc_alg(
     """
 
     start = time.time()
-    indep_test = CIT(data, indep_test)
+    indep_test = CIT(data, indep_test, **kwargs)
     ## Step 1: detect the direct causes of missingness indicators
     prt_m = get_parent_missingness_pairs(data, alpha, indep_test, stable)
     # print('Finish detecting the parents of missingness indicators.  ')

--- a/tests/TestPC.py
+++ b/tests/TestPC.py
@@ -1,4 +1,4 @@
-import os
+import os, time
 import sys
 sys.path.append("")
 import unittest
@@ -330,3 +330,26 @@ class TestPC(unittest.TestCase):
             print(f'{bname} ({num_nodes_in_truth} nodes/{num_edges_in_truth} edges): used {cg.PC_elapsed:.5f}s, SHD: {shd.get_shd()}')
 
         print('test_pc_load_bnlearn_discrete_datasets passed!\n')
+
+    # Test the usage of local cache checkpoint (check speed).
+    def test_pc_with_citest_local_checkpoint(self):
+        print('Now start test_pc_with_citest_local_checkpoint ...')
+        data_path = "./TestData/data_linear_10.txt"
+        citest_cache_file = "./TestData/citest_cache_linear_10_first_500_kci.json"
+
+        tic = time.time()
+        data = np.loadtxt(data_path, skiprows=1)[:500]
+        cg1 = pc(data, 0.05, kci, cache_path=citest_cache_file)
+        tac = time.time()
+        print(f'First pc run takes {tac - tic:.3f}s.')  # First pc run takes 125.663s.
+        assert os.path.exists(citest_cache_file), 'Cache file should exist.'
+
+        tic = time.time()
+        data = np.loadtxt(data_path, skiprows=1)[:500]
+        cg2 = pc(data, 0.05, kci, cache_path=citest_cache_file)
+        # you might also try other rules of PC, e.g., pc(data, 0.05, kci, True, 0, -1, cache_path=citest_cache_file)
+        tac = time.time()
+        print(f'Second pc run takes {tac - tic:.3f}s.')  # Second pc run takes 27.316s.
+        assert np.all(cg1.G.graph == cg2.G.graph), INCONSISTENT_RESULT_GRAPH_ERRMSG
+
+        print('test_pc_with_citest_local_checkpoint passed!\n')


### PR DESCRIPTION
### Updated files:

+ `TestPC.py`: added `test_pc_with_citest_local_checkpoint` as a usage example of save&load local cache checkpoints. Other usages on constraint-based methods (e.g., FCI and CDNOD) can be just referred to here.
+ `PC.py`, `FCI.py`, `CDNOD.py`: added kwargs to `func pc` to pass additional parameters to CIT (and possibly more for future usage).

### Why we need this:
+ A typical use case 1: `pc(uc_rule=0, ...)` then after the long run and viewing the results, I want to just finetune some params (e.g., `pc(uc_rule=2, ...)` - then I'll need to wait for another 6 hrs??? (though most of the CI tests (on skeleton discovery) are the same).
+ A typical use case 2: sometimes due to slow speed/some random error I interrupt the running PC. Then I need to run it again - I've already spent hours on it, and want to resume from the breaking point.
+ In the above cases, usually the CIT results can be resumed, so as to save almost all of the running time - especially when the graph scale is big or KCI is used - where CI tests consume almost all time.
+ So, we designed a user-specified feature (default as off), to write CITest cache from runtime (which we already have at #6) to some user-specified local path (which we implemented at #62).

### How to use this:
Just refer to `test_pc_with_citest_local_checkpoint` in `TestPC.py`:

For example, if we plan to use local cache, instead of directly use

```python
cg = pc(data, 0.05, kci)
```

as before, now we use

```python
citest_cache_file = "./TestData/citest_cache_linear_10_first_500_kci.json"    # .json file
cg = pc(data, 0.05, kci, cache_path=citest_cache_file)
```

If `citest_cache_file` does not exist in your local cache, a new one will be created. Otherwise, the cache will be first loaded from the json file to the CIT class and used during the runtime. Note that 1) data hash and parameters hash will first be checked at loading to ensure consistency, and 2) during runtime, the cache will be saved to the local file every 30 seconds.

### Test plan:

```python
python -m unittest TestPC.TestPC.test_pc_with_citest_local_checkpoint
```

The test should pass and console will show:

```
First pc run takes 125.663s.
Second pc run takes 27.316s.
```

Also a `"./TestData/citest_cache_linear_10_first_500_kci.json"` is saved. It will look like:

```json
{
  "data_hash": "41b2bb03b69f7aa5910437ce481cd09a",
  "method_name": "kci",
  "parameters_hash": "99914b932bd37a50b983c5e7c90ae93b",
  "0;1": 0.2909559404988158,
  "0;2": 0.0,
  "0;3": 0.0,
  "0;4": 0.00021451118990445384,
  "0;5": 0.0,
  "0;6": 6.658751283694642e-08,
  "0;7": 1.7363888105137448e-13,
  "0;8": 0.0,
  "0;9": 2.3744259060709538e-05,
  "0;10": 0.5269525537421107,
  "0;11": 0.32119609314891906,

...

  "1;12|0": 0.0,
  "1;12|3": 0.0,
  "1;12|4": 0.0,
  "1;12|7": 0.0,
  "1;12|17": 0.0,
  "1;12|19": 0.0,
  "3;12|1": 1.1102230246251565e-16,
  "3;12|6": 7.784628497375934e-11,
  "3;12|9": 4.080547788554156e-09,
  "3;12|15": 9.85247894380592e-09,
  "4;12|1": 0.0009963076474257537,
  "4;12|6": 4.189646983976392e-05,
  "4;12|7": 0.025117609530545315,
  "4;12|9": 0.06133924708469907,
  "4;12|11": 0.02263991680291122,
  "4;12|15": 0.013199259718645107,
  "4;12|17": 0.0019548269683874464,
  "6;12|3": 3.385422775448177e-08,
  "6;12|4": 2.5775825918117334e-11,
  "6;12|7": 7.315127963369861e-07,
  "6;12|9": 7.233954915086827e-07,
  "6;12|15": 1.267475481236957e-07,
  "6;12|17": 2.8023321030357096e-07,
  "6;12|19": 3.471212206562768e-11,
  "7;12|1": 9.992007221626409e-16,
  "7;12|4": 4.387676888484293e-10,
  "7;12|6": 1.062029930665176e-08,
  "7;12|9": 2.457501979691301e-10,
  "7;12|11": 2.1808488348540322e-10
}
```

### TODO:

To update the related examples/tutorials in the docs.



