### PR TITLE
Use d-separation as CIT in tests, to ensure PC's correctness

### DIFF
--- a/causallearn/search/ConstraintBased/CDNOD.py
+++ b/causallearn/search/ConstraintBased/CDNOD.py
@@ -16,7 +16,7 @@ from causallearn.search.ConstraintBased.PC import get_parent_missingness_pairs, 
 def cdnod(data: ndarray, c_indx: ndarray, alpha: float=0.05, indep_test: str=fisherz, stable: bool=True,
           uc_rule: int=0, uc_priority: int=2, mvcdnod: bool=False, correction_name: str='MV_Crtn_Fisher_Z',
           background_knowledge: Optional[BackgroundKnowledge]=None, verbose: bool=False,
-          show_progress: bool = True) -> CausalGraph:
+          show_progress: bool = True, **kwargs) -> CausalGraph:
     """
     Causal discovery from nonstationary/heterogeneous data
     phase 1: learning causal skeleton,
@@ -37,16 +37,16 @@ def cdnod(data: ndarray, c_indx: ndarray, alpha: float=0.05, indep_test: str=fis
     if mvcdnod:
         return mvcdnod_alg(data=data_aug, alpha=alpha, indep_test=indep_test, correction_name=correction_name,
                            stable=stable, uc_rule=uc_rule, uc_priority=uc_priority, verbose=verbose,
-                           show_progress=show_progress)
+                           show_progress=show_progress, **kwargs)
     else:
         return cdnod_alg(data=data_aug, alpha=alpha, indep_test=indep_test, stable=stable, uc_rule=uc_rule,
                          uc_priority=uc_priority, background_knowledge=background_knowledge, verbose=verbose,
-                         show_progress=show_progress)
+                         show_progress=show_progress, **kwargs)
 
 
 def cdnod_alg(data: ndarray, alpha: float, indep_test: str, stable: bool, uc_rule: int, uc_priority: int,
               background_knowledge: Optional[BackgroundKnowledge] = None, verbose: bool = False,
-              show_progress: bool = True) -> CausalGraph:
+              show_progress: bool = True, **kwargs) -> CausalGraph:
     """
     Perform Peter-Clark algorithm for causal discovery on the augmented data set that captures the unobserved changing factors
 
@@ -85,7 +85,7 @@ def cdnod_alg(data: ndarray, alpha: float, indep_test: str, stable: bool, uc_rul
 
     """
     start = time.time()
-    indep_test = CIT(data, indep_test)
+    indep_test = CIT(data, indep_test, **kwargs)
     cg_1 = SkeletonDiscovery.skeleton_discovery(data, alpha, indep_test, stable)
 
     # orient the direction from c_indx to X, if there is an edge between c_indx and X
@@ -127,7 +127,7 @@ def cdnod_alg(data: ndarray, alpha: float, indep_test: str, stable: bool, uc_rul
 
 
 def mvcdnod_alg(data: ndarray, alpha: float, indep_test: str, correction_name: str, stable: bool, uc_rule: int,
-                uc_priority: int, verbose: bool, show_progress: bool) -> CausalGraph:
+                uc_priority: int, verbose: bool, show_progress: bool, **kwargs) -> CausalGraph:
     """
     :param data: data set (numpy ndarray)
     :param alpha: desired significance level (float) in (0, 1)
@@ -156,7 +156,7 @@ def mvcdnod_alg(data: ndarray, alpha: float, indep_test: str, correction_name: s
     """
 
     start = time.time()
-    indep_test = CIT(data, indep_test)
+    indep_test = CIT(data, indep_test, **kwargs)
     ## Step 1: detect the direct causes of missingness indicators
     prt_m = get_parent_missingness_pairs(data, alpha, indep_test, stable)
     # print('Finish detecting the parents of missingness indicators.  ')

--- a/causallearn/search/ConstraintBased/FCI.py
+++ b/causallearn/search/ConstraintBased/FCI.py
@@ -729,7 +729,8 @@ def get_color_edges(graph: Graph) -> List[Edge]:
 
 
 def fci(dataset: ndarray, independence_test_method: str=fisherz, alpha: float = 0.05, depth: int = -1,
-        max_path_length: int = -1, verbose: bool = False, background_knowledge: BackgroundKnowledge | None = None) -> Tuple[Graph, List[Edge]]:
+        max_path_length: int = -1, verbose: bool = False, background_knowledge: BackgroundKnowledge | None = None,
+        **kwargs) -> Tuple[Graph, List[Edge]]:
     """
     Perform Fast Causal Inference (FCI) algorithm for causal discovery
 
@@ -766,7 +767,7 @@ def fci(dataset: ndarray, independence_test_method: str=fisherz, alpha: float = 
     if dataset.shape[0] < dataset.shape[1]:
         warnings.warn("The number of features is much larger than the sample size!")
 
-    independence_test_method = CIT(dataset, method=independence_test_method)
+    independence_test_method = CIT(dataset, method=independence_test_method, **kwargs)
 
     ## ------- check parameters ------------
     if (depth is None) or type(depth) != int:

--- a/causallearn/search/ConstraintBased/PC.py
+++ b/causallearn/search/ConstraintBased/PC.py
@@ -29,7 +29,8 @@ def pc(
     background_knowledge: BackgroundKnowledge | None = None, 
     verbose: bool = False, 
     show_progress: bool = True,
-    node_names: List[str] | None = None, 
+    node_names: List[str] | None = None,
+    **kwargs
 ):
     if data.shape[0] < data.shape[1]:
         warnings.warn("The number of features is much larger than the sample size!")
@@ -40,11 +41,11 @@ def pc(
         return mvpc_alg(data=data, node_names=node_names, alpha=alpha, indep_test=indep_test, correction_name=correction_name, stable=stable,
                         uc_rule=uc_rule, uc_priority=uc_priority, background_knowledge=background_knowledge,
                         verbose=verbose,
-                        show_progress=show_progress)
+                        show_progress=show_progress, **kwargs)
     else:
         return pc_alg(data=data, node_names=node_names, alpha=alpha, indep_test=indep_test, stable=stable, uc_rule=uc_rule,
                       uc_priority=uc_priority, background_knowledge=background_knowledge, verbose=verbose,
-                      show_progress=show_progress)
+                      show_progress=show_progress, **kwargs)
 
 
 def pc_alg(
@@ -58,6 +59,7 @@ def pc_alg(
     background_knowledge: BackgroundKnowledge | None = None,
     verbose: bool = False,
     show_progress: bool = True,
+    **kwargs
 ) -> CausalGraph:
     """
     Perform Peter-Clark (PC) algorithm for causal discovery
@@ -98,7 +100,7 @@ def pc_alg(
     """
 
     start = time.time()
-    indep_test = CIT(data, indep_test)
+    indep_test = CIT(data, indep_test, **kwargs)
     cg_1 = SkeletonDiscovery.skeleton_discovery(data, alpha, indep_test, stable,
                                                 background_knowledge=background_knowledge, verbose=verbose,
                                                 show_progress=show_progress, node_names=node_names)
@@ -148,6 +150,7 @@ def mvpc_alg(
     background_knowledge: BackgroundKnowledge | None = None,
     verbose: bool = False,
     show_progress: bool = True,
+    **kwargs,
 ) -> CausalGraph:
     """
     Perform missing value Peter-Clark (PC) algorithm for causal discovery
@@ -192,7 +195,7 @@ def mvpc_alg(
     """
 
     start = time.time()
-    indep_test = CIT(data, indep_test)
+    indep_test = CIT(data, indep_test, **kwargs)
     ## Step 1: detect the direct causes of missingness indicators
     prt_m = get_parent_missingness_pairs(data, alpha, indep_test, stable)
     # print('Finish detecting the parents of missingness indicators.  ')

--- a/tests/TestPC.py
+++ b/tests/TestPC.py
@@ -1,4 +1,4 @@
-import os
+import os, time
 import sys
 sys.path.append("")
 import unittest
@@ -330,3 +330,26 @@ class TestPC(unittest.TestCase):
             print(f'{bname} ({num_nodes_in_truth} nodes/{num_edges_in_truth} edges): used {cg.PC_elapsed:.5f}s, SHD: {shd.get_shd()}')
 
         print('test_pc_load_bnlearn_discrete_datasets passed!\n')
+
+    # Test the usage of local cache checkpoint (check speed).
+    def test_pc_with_citest_local_checkpoint(self):
+        print('Now start test_pc_with_citest_local_checkpoint ...')
+        data_path = "./TestData/data_linear_10.txt"
+        citest_cache_file = "./TestData/citest_cache_linear_10_first_500_kci.json"
+
+        tic = time.time()
+        data = np.loadtxt(data_path, skiprows=1)[:500]
+        cg1 = pc(data, 0.05, kci, cache_path=citest_cache_file)
+        tac = time.time()
+        print(f'First pc run takes {tac - tic:.3f}s.')  # First pc run takes 125.663s.
+        assert os.path.exists(citest_cache_file), 'Cache file should exist.'
+
+        tic = time.time()
+        data = np.loadtxt(data_path, skiprows=1)[:500]
+        cg2 = pc(data, 0.05, kci, cache_path=citest_cache_file)
+        # you might also try other rules of PC, e.g., pc(data, 0.05, kci, True, 0, -1, cache_path=citest_cache_file)
+        tac = time.time()
+        print(f'Second pc run takes {tac - tic:.3f}s.')  # Second pc run takes 27.316s.
+        assert np.all(cg1.G.graph == cg2.G.graph), INCONSISTENT_RESULT_GRAPH_ERRMSG
+
+        print('test_pc_with_citest_local_checkpoint passed!\n')

--- a/tests/TestPC.py
+++ b/tests/TestPC.py
@@ -377,6 +377,7 @@ class TestPC(unittest.TestCase):
             data = np.zeros((100, len(truth_dag.nodes)))  # just a placeholder
             cg = pc(data, 0.05, d_separation, True, 0, -1, true_dag=true_dag_netx)
             shd = SHD(truth_cpdag, cg.G)
+            self.assertEqual(0, shd, "PC with d-separation as CIT returns an inaccurate CPDAG.")
             print(f'{bname} ({num_nodes_in_truth} nodes/{num_edges_in_truth} edges): used {cg.PC_elapsed:.5f}s, SHD: {shd.get_shd()}')
 
         print('test_pc_load_bnlearn_graphs_with_d_separation passed!\n')


### PR DESCRIPTION
### Note first: ###
This pr is based off of #64 to prevent conflict on `TestPC.py`. So please review #64 first.

### Updated files: ###
+ `cit.py`: add `class D_Separation(CIT_Base)`.
+ `TestPC.py`: add `test_pc_load_bnlearn_graphs_with_d_separation`.

### Test plan: ###

```
python -m unittest TestPC.TestPC.test_pc_load_bnlearn_graphs_with_d_separation
```

It should pass (but in long time (around 3hrs), since in big graphs: 1) more tests are needed, and 2) d-separation check takes more time to traverse paths). Here is an example output:

```
Depth=3, working on node 7: 100%|██████████| 8/8 [00:00<00:00, 6425.59it/s]
asia (8 nodes/8 edges): used 0.03562s, SHD: 0
Depth=3, working on node 4: 100%|██████████| 5/5 [00:00<00:00, 5866.16it/s]
cancer (5 nodes/4 edges): used 0.00914s, SHD: 0
Depth=3, working on node 4: 100%|██████████| 5/5 [00:00<00:00, 6878.16it/s]
earthquake (5 nodes/4 edges): used 0.00925s, SHD: 0
Depth=6, working on node 10: 100%|██████████| 11/11 [00:00<00:00, 5876.62it/s]
sachs (11 nodes/17 edges): used 0.13420s, SHD: 0
Depth=3, working on node 5: 100%|██████████| 6/6 [00:00<00:00, 7246.13it/s]
survey (6 nodes/6 edges): used 0.01338s, SHD: 0
Depth=5, working on node 36: 100%|██████████| 37/37 [00:00<00:00, 8497.93it/s]
alarm (37 nodes/46 edges): used 7.56482s, SHD: 0
Depth=7, working on node 47: 100%|██████████| 48/48 [00:00<00:00, 3848.28it/s]
barley (48 nodes/84 edges): used 701.48529s, SHD: 0
Depth=7, working on node 19: 100%|██████████| 20/20 [00:00<00:00, 7347.47it/s]
child (20 nodes/25 edges): used 0.97726s, SHD: 0
Depth=8, working on node 26: 100%|██████████| 27/27 [00:00<00:00, 7440.13it/s]
insurance (27 nodes/52 edges): used 21.79384s, SHD: 0
Depth=7, working on node 31: 100%|██████████| 32/32 [00:00<00:00, 4703.78it/s]
water (32 nodes/66 edges): used 122.41981s, SHD: 0
Depth=16, working on node 55: 100%|██████████| 56/56 [00:00<00:00, 6383.16it/s]
hailfinder (56 nodes/66 edges): used 365.14324s, SHD: 0
Depth=18, working on node 69: 100%|██████████| 70/70 [00:00<00:00, 3397.89it/s]
hepar2 (70 nodes/123 edges): used 7126.62941s, SHD: 0
Depth=9, working on node 75: 100%|██████████| 76/76 [00:00<00:00, 7891.84it/s]
win95pts (76 nodes/112 edges): used 167.08235s, SHD: 0
test_pc_load_bnlearn_graphs_with_d_separation passed!

Ran 1 test in 8514.537s
```
### Good news from above: ###

By this integration test, we know that our current implementation of pc (or more specifically, at least `pc(stable=True, uc_rule=0, uc_priority=-1)`) is correct, i.e., it will return the true CPDAG with asymptotic CI tests. 